### PR TITLE
feat: コマンドとして実行できるエントリーポイントを追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ name = "personal-mcp-core"
 version = "0.1.0"
 requires-python = ">=3.10"
 
+[project.scripts]
+personal-mcp = "personal_mcp.server:main"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/src/personal_mcp/server.py
+++ b/src/personal_mcp/server.py
@@ -1,12 +1,10 @@
-from personal_mcp.adapters.mcp_server import get_system_context
-
-
-def main():
-    # Placeholder entrypoint
-    context = get_system_context()
-    print("System context loaded.")
-    print(f"Length: {len(context)} characters")
-
+# src/personal_mcp/server.py
+def main() -> int:
+    # TODO: replace with real MCP server wiring later
+    from personal_mcp.adapters.mcp_server import get_system_context
+    text = get_system_context()
+    print(f"loaded system context: {len(text)} chars")
+    return 0
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `pyproject.toml` に `[project.scripts]` を追加し、`personal-mcp` コマンドとして実行できるようにした
- `server.py` の `main()` を `int` を返すよう変更し、`SystemExit` で終了コードを返すように修正

## Test plan

- [x] `pip install -e .` 後に `personal-mcp` コマンドが実行できることを確認
- [x] `python -m personal_mcp.server` でも引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)