### PR TITLE
feat: 共通 Event スキーマ定義 (core/event.py) #10

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,3 +66,49 @@ Tradeoff: manual sync is required. Accepted because the file changes rarely.
 The real MCP server requires an MCP library dependency (e.g., `mcp` or `fastmcp`).
 That dependency has not been added yet to keep the package installable without
 external requirements. The placeholder prints context length to verify the load path.
+
+## Event schema
+
+> Defined in `src/personal_mcp/core/event.py`.
+> Current status: **schema definition only** — no write logic is implemented here.
+
+### Purpose
+
+All domains (poe2, mood, general) converge to a single `Event` type so that:
+
+- Storage code (`append_jsonl`) needs no domain-specific branches.
+- History can be reconstructed from JSONL files alone, without domain knowledge.
+- Future adapters can filter or aggregate events using the common `domain` and `tags` fields.
+
+### Fields
+
+| Field     | Type              | Description                                              |
+|-----------|-------------------|----------------------------------------------------------|
+| `ts`      | `str`             | ISO 8601 timestamp (UTC recommended)                     |
+| `domain`  | `str`             | Source domain — e.g. `"poe2"`, `"mood"`, `"general"`    |
+| `payload` | `Dict[str, Any]`  | Domain-specific data; all values must be JSON-serializable |
+| `tags`    | `List[str]`       | Optional labels for filtering; use `[]` if not needed    |
+
+### JSONL example
+
+```python
+from dataclasses import asdict
+from personal_mcp.core.event import Event
+
+event = Event(
+    ts="2026-03-03T12:00:00+00:00",
+    domain="poe2",
+    payload={"text": "ボスを倒した", "kind": "note"},
+    tags=["boss", "victory"],
+)
+
+asdict(event)
+# {
+#   "ts": "2026-03-03T12:00:00+00:00",
+#   "domain": "poe2",
+#   "payload": {"text": "ボスを倒した", "kind": "note"},
+#   "tags": ["boss", "victory"]
+# }
+```
+
+`asdict(event)` の結果はそのまま `append_jsonl(path, asdict(event))` に渡せる。

--- a/src/personal_mcp/core/event.py
+++ b/src/personal_mcp/core/event.py
@@ -1,0 +1,25 @@
+# src/personal_mcp/core/event.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class Event:
+    """Common event schema for all domains (poe2, mood, general).
+
+    All fields are JSON-serializable, so dataclasses.asdict(event)
+    can be passed directly to append_jsonl without transformation.
+
+    Fields:
+        ts:      ISO 8601 timestamp string (UTC recommended)
+        domain:  Source domain, e.g. "poe2", "mood", "general"
+        payload: Domain-specific data; must contain only JSON-serializable values
+        tags:    Optional labels for filtering; use empty list if not needed
+    """
+
+    ts: str
+    domain: str
+    payload: Dict[str, Any]
+    tags: List[str]


### PR DESCRIPTION
## Summary

- `src/personal_mcp/core/event.py` を新規追加: `ts / domain / payload / tags` を持つ共通 `Event` dataclass
- `docs/architecture.md` に「Event スキーマ」節を追記（目的・フィールド一覧・JSONL 例・スキーマ定義のみであることの明記）

## 受け入れ条件の確認

- `from personal_mcp.core.event import Event` — OK
- `Event(ts=..., domain="poe2", payload={...}, tags=[])` の構築 — OK
- `asdict(event)` が JSON 化可能で `append_jsonl` に直渡し可能な構造 — OK（`json.dumps` で検証済み）

## スコープ外（含めていないもの）

- CLI コマンドの実装なし
- 既存 poe2 コード（`Poe2Log` 等）への変更なし

## Test plan

- [x] `python -c "from personal_mcp.core.event import Event; from dataclasses import asdict; import json; e = Event(ts='2026-03-03T12:00:00+00:00', domain='poe2', payload={'text': 'test'}, tags=[]); print(json.dumps(asdict(e)))"` が正常終了すること
- [x] `python -m compileall src/personal_mcp/core/event.py` がエラーなく完了すること

Closes #10
Blocks #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)