### PR TITLE
feat: event-add CLIコマンド実装 (data/events.jsonl)

### DIFF
--- a/src/personal_mcp/server.py
+++ b/src/personal_mcp/server.py
@@ -6,12 +6,20 @@ import json
 from typing import Any, Dict, List, Optional
 
 from personal_mcp.adapters.mcp_server import get_system_context
+from personal_mcp.tools.event import event_add
 from personal_mcp.tools.poe2_log import log_add, log_list
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(prog="personal-mcp")
     sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_event = sub.add_parser("event-add", help="append an event to data/events.jsonl")
+    p_event.add_argument("text", help="event text")
+    p_event.add_argument("--domain", required=True, help="event domain (e.g. poe2, mood)")
+    p_event.add_argument("--tags", default="")
+    p_event.add_argument("--meta-json", default=None)
+    p_event.add_argument("--data-dir", default="data")
 
     p_log = sub.add_parser("poe2-log-add", help="append a poe2 log entry")
     p_log.add_argument("text", help="log text")
@@ -30,6 +38,19 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_list.add_argument("--json", action="store_true")
 
     args = parser.parse_args(argv)
+
+    if args.cmd == "event-add":
+        tags = [t for t in args.tags.split(",") if t] if args.tags else []
+        meta: Optional[Dict[str, Any]] = json.loads(args.meta_json) if args.meta_json else None
+        rec = event_add(
+            domain=args.domain,
+            text=args.text,
+            tags=tags,
+            meta=meta,
+            data_dir=args.data_dir,
+        )
+        print(json.dumps(rec, ensure_ascii=False, indent=2))
+        return 0
 
     if args.cmd == "info":
         text = get_system_context()

--- a/src/personal_mcp/tools/event.py
+++ b/src/personal_mcp/tools/event.py
@@ -1,0 +1,38 @@
+# src/personal_mcp/tools/event.py
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from personal_mcp.core.event import Event
+from personal_mcp.storage.jsonl import append_jsonl
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def event_add(
+    domain: str,
+    text: str,
+    tags: Optional[List[str]] = None,
+    meta: Optional[Dict[str, Any]] = None,
+    data_dir: str = "data",
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"text": text}
+    if meta:
+        payload["meta"] = meta
+
+    event = Event(
+        ts=_now_iso(),
+        domain=domain,
+        payload=payload,
+        tags=tags or [],
+    )
+
+    path = Path(data_dir) / "events.jsonl"
+    record = asdict(event)
+    append_jsonl(path, record)
+    return record

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+from personal_mcp.tools.event import event_add
+
+
+def test_event_add_creates_jsonl_with_one_line(data_dir: Path) -> None:
+    path = data_dir / "events.jsonl"
+    event_add(domain="poe2", text="test", data_dir=str(data_dir))
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["domain"] == "poe2"
+    assert record["payload"]["text"] == "test"
+
+
+def test_event_add_appends_without_overwriting(data_dir: Path) -> None:
+    path = data_dir / "events.jsonl"
+    path.write_text('{"dummy": true}\n', encoding="utf-8")
+
+    event_add(domain="mood", text="second", data_dir=str(data_dir))
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"dummy": True}
+    record = json.loads(lines[1])
+    assert record["domain"] == "mood"
+    assert record["payload"]["text"] == "second"


### PR DESCRIPTION
## Summary

- `src/personal_mcp/tools/event.py` 新規作成 — `event_add(domain, text, tags, meta, data_dir)` を実装
- `src/personal_mcp/server.py` 修正 — `event-add` サブコマンドを追加（`--domain` 必須）
- `tests/test_event.py` 新規作成 — append-only 動作を確認する2件のテスト

## 動作確認

```bash
python -m personal_mcp.server event-add --domain poe2 "test"
# → data/events.jsonl に1行追記され、追記した JSON を標準出力に表示
```

## 設計メモ

- `text` は `payload["text"]` に格納。`meta` は `payload["meta"]` にネスト（キー衝突回避）
- 書き込みは `append_jsonl` のみ使用。ファイル読み取り・書き換えは行わない
- `data/poe2/logs.jsonl` には一切触れない

## Test plan

- [x] `pytest tests/test_event.py` — 2 passed
- [x] `pytest tests/test_jsonl.py` — 2 passed (既存テスト継続通過)

closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)