### PR TITLE
feat: event-list 日次タイムライン表示 (#13)

### DIFF
--- a/src/personal_mcp/server.py
+++ b/src/personal_mcp/server.py
@@ -3,11 +3,51 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from personal_mcp.adapters.mcp_server import get_system_context
-from personal_mcp.tools.event import event_add
+from personal_mcp.tools.event import event_add, event_list
 from personal_mcp.tools.poe2_log import log_add, log_list
+
+
+def _print_event_timeline(records: List[Dict[str, Any]]) -> None:
+    """Print events grouped by local date, newest date first.
+
+    Format:
+        --- YYYY-MM-DD ---
+        HH:MM [domain] text
+    """
+    def local_date(r: Dict[str, Any]) -> str:
+        try:
+            return datetime.fromisoformat(r.get("ts", "")).astimezone().strftime("%Y-%m-%d")
+        except Exception:
+            return "unknown"
+
+    def local_time(r: Dict[str, Any]) -> str:
+        try:
+            return datetime.fromisoformat(r.get("ts", "")).astimezone().strftime("%H:%M")
+        except Exception:
+            return "??:??"
+
+    # records are newest-first; preserve that order for date grouping
+    seen: List[str] = []
+    groups: Dict[str, List[Dict[str, Any]]] = {}
+    for r in records:
+        d = local_date(r)
+        if d not in groups:
+            seen.append(d)
+            groups[d] = []
+        groups[d].append(r)
+
+    for d in seen:
+        print(f"--- {d} ---")
+        # within each date, display in chronological order (oldest first)
+        for r in reversed(groups[d]):
+            t = local_time(r)
+            dom = r.get("domain", "?")
+            text = r.get("payload", {}).get("text", "")
+            print(f"{t} [{dom}] {text}")
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -20,6 +60,14 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_event.add_argument("--tags", default="")
     p_event.add_argument("--meta-json", default=None)
     p_event.add_argument("--data-dir", default="data")
+
+    p_elist = sub.add_parser("event-list", help="list events from data/events.jsonl")
+    p_elist.add_argument("--n", type=int, default=20)
+    p_elist.add_argument("--domain", default=None)
+    p_elist.add_argument("--date", default=None, metavar="YYYY-MM-DD")
+    p_elist.add_argument("--since", default=None)
+    p_elist.add_argument("--data-dir", default="data")
+    p_elist.add_argument("--json", action="store_true")
 
     p_log = sub.add_parser("poe2-log-add", help="append a poe2 log entry")
     p_log.add_argument("text", help="log text")
@@ -38,6 +86,20 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_list.add_argument("--json", action="store_true")
 
     args = parser.parse_args(argv)
+
+    if args.cmd == "event-list":
+        records = event_list(
+            n=args.n,
+            domain=args.domain,
+            date=args.date,
+            since=args.since,
+            data_dir=args.data_dir,
+        )
+        if args.json:
+            print(json.dumps(records, ensure_ascii=False, indent=2))
+        else:
+            _print_event_timeline(records)
+        return 0
 
     if args.cmd == "event-add":
         tags = [t for t in args.tags.split(",") if t] if args.tags else []

--- a/src/personal_mcp/tools/event.py
+++ b/src/personal_mcp/tools/event.py
@@ -7,11 +7,24 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from personal_mcp.core.event import Event
-from personal_mcp.storage.jsonl import append_jsonl
+from personal_mcp.storage.jsonl import append_jsonl, read_jsonl
 
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_since(since: Optional[str]) -> Optional[datetime]:
+    """Parse --since value to a timezone-aware datetime.
+
+    "YYYY-MM-DD" is treated as UTC midnight (start of that day in UTC).
+    ISO datetime strings are parsed as-is (must include timezone offset).
+    """
+    if not since:
+        return None
+    if len(since) == 10 and since[4] == "-" and since[7] == "-":
+        return datetime.fromisoformat(since + "T00:00:00+00:00")
+    return datetime.fromisoformat(since)
 
 
 def event_add(
@@ -36,3 +49,50 @@ def event_add(
     record = asdict(event)
     append_jsonl(path, record)
     return record
+
+
+def event_list(
+    n: int = 20,
+    domain: Optional[str] = None,
+    date: Optional[str] = None,
+    since: Optional[str] = None,
+    data_dir: str = "data",
+) -> List[Dict[str, Any]]:
+    """Return filtered events, newest first, limited to n records.
+
+    --domain: include only events matching this domain string.
+    --date:   include only events whose local date equals YYYY-MM-DD.
+    --since:  earliest timestamp (inclusive). "YYYY-MM-DD" means UTC midnight of
+              that date; ISO datetime strings are used as-is.
+    --n:      after all filters, return the newest n records (newest first).
+
+    events.jsonl が存在しない場合は空リストを返す（書き込みは一切しない）。
+    """
+    path = Path(data_dir) / "events.jsonl"
+    rows = read_jsonl(path)
+
+    since_dt = _parse_since(since)
+
+    def ok(r: Dict[str, Any]) -> bool:
+        if domain and r.get("domain") != domain:
+            return False
+        ts_str = r.get("ts")
+        if not ts_str:
+            return True
+        try:
+            ts_dt = datetime.fromisoformat(ts_str)
+            if ts_dt.tzinfo is None:
+                ts_dt = ts_dt.replace(tzinfo=timezone.utc)
+        except Exception:
+            return True
+        if since_dt and ts_dt < since_dt:
+            return False
+        if date:
+            local_date = ts_dt.astimezone().strftime("%Y-%m-%d")
+            if local_date != date:
+                return False
+        return True
+
+    filtered = [r for r in rows if ok(r)]
+    # newest first, then take up to n records
+    return list(reversed(filtered))[: max(0, n)]

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,8 +1,28 @@
 import json
+from datetime import datetime
 from pathlib import Path
 
-from personal_mcp.tools.event import event_add
+import pytest
 
+from personal_mcp.tools.event import event_add, event_list
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _local_date(ts_str: str) -> str:
+    """Convert ISO timestamp to local YYYY-MM-DD (timezone-agnostic)."""
+    return datetime.fromisoformat(ts_str).astimezone().strftime("%Y-%m-%d")
+
+
+def _write_events(path: Path, events: list) -> None:
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# event_add tests (existing)
+# ---------------------------------------------------------------------------
 
 def test_event_add_creates_jsonl_with_one_line(data_dir: Path) -> None:
     path = data_dir / "events.jsonl"
@@ -27,3 +47,152 @@ def test_event_add_appends_without_overwriting(data_dir: Path) -> None:
     record = json.loads(lines[1])
     assert record["domain"] == "mood"
     assert record["payload"]["text"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# event_list tests
+# ---------------------------------------------------------------------------
+
+# Use noon UTC so local date is consistent across UTC-11 to UTC+11 timezones
+_TS_DAY1_A = "2026-03-02T12:00:00+00:00"  # day1
+_TS_DAY2_A = "2026-03-03T12:00:00+00:00"  # day2 morning
+_TS_DAY2_B = "2026-03-03T14:00:00+00:00"  # day2 afternoon
+
+_EVENTS = [
+    {"ts": _TS_DAY1_A, "domain": "mood",    "payload": {"text": "day1 mood"},    "tags": []},
+    {"ts": _TS_DAY2_A, "domain": "poe2",    "payload": {"text": "day2 poe2"},    "tags": ["farming"]},
+    {"ts": _TS_DAY2_B, "domain": "general", "payload": {"text": "day2 general"}, "tags": []},
+]
+
+
+def test_event_list_returns_empty_when_file_missing(data_dir: Path) -> None:
+    result = event_list(data_dir=str(data_dir))
+    assert result == []
+
+
+def test_event_list_returns_all_events(data_dir: Path) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    result = event_list(data_dir=str(data_dir))
+    assert len(result) == 3
+
+
+def test_event_list_newest_first(data_dir: Path) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    result = event_list(data_dir=str(data_dir))
+    texts = [r["payload"]["text"] for r in result]
+    # newest event (day2 afternoon) should come first
+    assert texts[0] == "day2 general"
+    assert texts[-1] == "day1 mood"
+
+
+def test_event_list_filter_by_domain(data_dir: Path) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    result = event_list(domain="poe2", data_dir=str(data_dir))
+    assert len(result) == 1
+    assert result[0]["domain"] == "poe2"
+    assert result[0]["payload"]["text"] == "day2 poe2"
+
+
+def test_event_list_filter_by_date(data_dir: Path) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    day2 = _local_date(_TS_DAY2_A)
+    result = event_list(date=day2, data_dir=str(data_dir))
+    assert len(result) == 2
+    texts = {r["payload"]["text"] for r in result}
+    assert texts == {"day2 poe2", "day2 general"}
+
+
+def test_event_list_filter_by_date_excludes_other_days(data_dir: Path) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    day1 = _local_date(_TS_DAY1_A)
+    result = event_list(date=day1, data_dir=str(data_dir))
+    assert len(result) == 1
+    assert result[0]["payload"]["text"] == "day1 mood"
+
+
+def test_event_list_filter_by_since(data_dir: Path) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    # since day2 UTC: should exclude day1 event
+    result = event_list(since="2026-03-03", data_dir=str(data_dir))
+    assert len(result) == 2
+    texts = {r["payload"]["text"] for r in result}
+    assert "day1 mood" not in texts
+
+
+def test_event_list_limit_n(data_dir: Path) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    result = event_list(n=1, data_dir=str(data_dir))
+    assert len(result) == 1
+    # should be the newest
+    assert result[0]["payload"]["text"] == "day2 general"
+
+
+def test_event_list_empty_for_unmatched_domain(data_dir: Path) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    result = event_list(domain="nonexistent", data_dir=str(data_dir))
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# text output format tests (via server.main)
+# ---------------------------------------------------------------------------
+
+def test_event_list_text_has_date_header(data_dir: Path, capsys: pytest.CaptureFixture) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+    day2 = _local_date(_TS_DAY2_A)
+
+    from personal_mcp.server import main
+    main(["event-list", "--date", day2, "--data-dir", str(data_dir)])
+
+    captured = capsys.readouterr()
+    assert f"--- {day2} ---" in captured.out
+    assert "[poe2]" in captured.out
+    assert "[general]" in captured.out
+    # must not contain other date's header
+    day1 = _local_date(_TS_DAY1_A)
+    if day1 != day2:
+        assert f"--- {day1} ---" not in captured.out
+
+
+def test_event_list_text_no_output_when_empty(data_dir: Path, capsys: pytest.CaptureFixture) -> None:
+    from personal_mcp.server import main
+    main(["event-list", "--data-dir", str(data_dir)])
+    captured = capsys.readouterr()
+    assert captured.out.strip() == ""
+
+
+def test_event_list_json_flag_returns_array(data_dir: Path, capsys: pytest.CaptureFixture) -> None:
+    _write_events(data_dir / "events.jsonl", _EVENTS)
+
+    from personal_mcp.server import main
+    main(["event-list", "--json", "--data-dir", str(data_dir)])
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 3
+    # no text headers in JSON output
+    assert "---" not in captured.out
+
+
+def test_event_list_json_empty_is_array(data_dir: Path, capsys: pytest.CaptureFixture) -> None:
+    from personal_mcp.server import main
+    main(["event-list", "--json", "--data-dir", str(data_dir)])
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed == []
+
+
+def test_event_list_text_line_format(data_dir: Path, capsys: pytest.CaptureFixture) -> None:
+    """Each detail line must match 'HH:MM [domain] text'."""
+    _write_events(data_dir / "events.jsonl", [_EVENTS[1]])  # day2 poe2 only
+
+    from personal_mcp.server import main
+    main(["event-list", "--data-dir", str(data_dir)])
+
+    captured = capsys.readouterr()
+    lines = [l for l in captured.out.splitlines() if not l.startswith("---")]
+    assert len(lines) == 1
+    # format: HH:MM [domain] text
+    import re
+    assert re.match(r"^\d{2}:\d{2} \[poe2\] day2 poe2$", lines[0])


### PR DESCRIPTION
## Summary

- `event_list()` を `tools/event.py` に実装（`--domain` / `--date` / `--since` / `--n` フィルタ対応）
- `event-list` サブコマンドを `server.py` に追加（テキスト / `--json` 出力の分岐）
- テキスト出力形式: `--- YYYY-MM-DD ---` ヘッダ + `HH:MM [domain] text` 明細行
- `tests/test_event.py` に 14 件のテストを追加（全 18 件通過）

## 設計上の判断

- `--since YYYY-MM-DD` は UTC 00:00:00 として扱う（`poe2-log-list` と同方式）
- `--date` はサーバのローカル時刻基準（ISO タイムスタンプを `astimezone()` 変換）
- `--n` はフィルタ後の最新 n 件。日付グループは新しい順、グループ内は時系列昇順
- `events.jsonl` への書き込みは一切行わない（読み取り専用）
- ファイル不在 → 空出力で正常終了（件数や評価的文言は出力しない）

## Test plan

- [x] `pytest` 18 件すべて通過を確認
- [x] `personal-mcp event-list --date YYYY-MM-DD` でヘッダ付きタイムラインが出る
- [x] `personal-mcp event-list --json` で配列 JSON のみ出力される（ヘッダ行なし）
- [x] `events.jsonl` が存在しないときは何も出力されない

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)