### PR TITLE
docs: clarify eng/worklog event contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 MVP の中核はすでに実装されている。現在は共通イベント基盤で記録し、PoE2 はその上の代表ユースケースとして扱っている。
 
 ```bash
-# 任意ドメインのイベントを追加する
+# eng / worklog など明示サポート domain のイベントを追加する
 python -m personal_mcp.server event-add "設計メモを書いた" \
   --domain=worklog --tags=design,docs
 
@@ -67,26 +67,137 @@ python -m personal_mcp.server poe2-watch --client-log /path/to/Client.txt
 
 ## データモデル方針
 
-イベントは共通 JSONL 形式で表現する：
+イベントは共通 JSONL 形式（`data/events.jsonl`）で表現する。追記のみ。編集・削除はしない。
 
-| フィールド | 説明 |
+### 最小イベント契約
+
+| フィールド | 必須/推奨 | 説明 |
+| --- | --- | --- |
+| `ts` | 必須 | タイムスタンプ（ISO 8601 タイムゾーン付き）。内部保存は UTC を原則とする |
+| `domain` | 必須 | ドメイン識別子（下記 MVP 許可リストを参照） |
+| `payload.text` | 必須 | 記録本文 |
+| `tags` | 必須 | タグリスト（空配列可） |
+| `payload.meta.kind` | 推奨 | イベント種別（`note` / `session` / `milestone` など） |
+| `payload.meta.source` | 推奨 | データ取得元（`"manual"` など） |
+| `payload.meta.ref` | 推奨 | 参照先（Issue 番号など） |
+
+`payload.meta` ごと省略できる（`poe2-watch` による自動記録など）。新しいトップレベルフィールドは追加しない。
+
+### タイムスタンプ方針
+
+- 内部保存は UTC を原則とする（実装の `_now_iso()` は `datetime.now(timezone.utc).isoformat()` を使用）
+- ドキュメント上のイベント例は読みやすさのため JST（`+09:00`）で表記する
+- 保存フォーマット自体はタイムゾーン付き ISO 8601 とし、既存レコードのオフセットはそのまま保持する
+
+### MVP で明示サポートする domain
+
+| domain | 説明 |
 | --- | --- |
-| `ts` | タイムスタンプ（UTC ISO 8601） |
-| `domain` | ドメイン（`poe2` / `mood` / `general` / 任意文字列） |
-| `payload.text` | 記録本文 |
-| `payload.meta` | 補助情報（任意。PoE2 の `kind` や自動取得元など） |
-| `tags` | タグリスト |
+| `poe2` | Path of Exile 2 の活動記録 |
+| `mood` | 気分・体調記録 |
+| `general` | 分類不要なメモや雑記 |
+| `eng` | エンジニアリング全般（調査・設計・学習など） |
+| `worklog` | 作業記録・進捗ログ |
 
-**現在の実装：**
+**domain 命名ルール：**
+
+- ASCII 小文字
+- 単数名詞または短いカテゴリ名
+- 区切りは必要時のみ `_`
+- `eng` は広いエンジニアリング活動（調査・設計・思考）、`worklog` は具体的な作業記録（セッション・進捗）として使い分ける
+
+`event-add` は技術上任意文字列を受け付けるが、MVP の明示サポート対象は上記のみとする。追加 domain は別 issue で定義する。
+
+### eng / worklog の最小 kind セット
+
+`payload.meta.kind` に設定する推奨値（`eng` / `worklog` 向け）：
+
+| kind | 用途 |
+| --- | --- |
+| `note` | 調査メモ、気づき、短い記録 |
+| `session` | 作業セッション、切り分け、実施ログ |
+| `milestone` | 方針確定、区切り、到達点 |
+
+### イベント例
+
+#### eng / note
+
+```json
+{
+  "ts": "2026-03-04T18:00:00+09:00",
+  "domain": "eng",
+  "payload": {
+    "text": "MCP adapterの調査メモ",
+    "meta": {
+      "kind": "note",
+      "source": "manual"
+    }
+  },
+  "tags": ["research"]
+}
+```
+
+#### worklog / session
+
+```json
+{
+  "ts": "2026-03-04T19:00:00+09:00",
+  "domain": "worklog",
+  "payload": {
+    "text": "Issue #23の切り分け",
+    "meta": {
+      "kind": "session",
+      "ref": "#23"
+    }
+  },
+  "tags": ["debug"]
+}
+```
+
+#### eng / milestone
+
+```json
+{
+  "ts": "2026-03-04T20:00:00+09:00",
+  "domain": "eng",
+  "payload": {
+    "text": "JSONL append-only方針を確認",
+    "meta": {
+      "kind": "milestone"
+    }
+  },
+  "tags": ["schema"]
+}
+```
+
+#### worklog / note
+
+```json
+{
+  "ts": "2026-03-04T21:00:00+09:00",
+  "domain": "worklog",
+  "payload": {
+    "text": "レビュー前に再現手順を整理",
+    "meta": {
+      "kind": "note",
+      "source": "manual"
+    }
+  },
+  "tags": ["review"]
+}
+```
+
+### 現在の実装
 
 - 汎用 `event-add` / `event-list` / `event-today` がある
 - `mood-add` は `domain="mood"` のイベントとして保存する
 - `poe2-log-add` / `poe2-log-list` は `domain="poe2"` の専用入口として動く
 - `poe2-watch` は `Client.txt` から `area_transition` を自動記録する
 
-**原則：**
+### 原則
 
 - 追記のみ。編集・削除はしない。
+- 既存 `poe2` / `mood` / `general` のレコード形式を壊さない。
 - 自動取得を後から足すときも、同じイベント形式で追加する。
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,7 +101,7 @@ external requirements. The placeholder prints context length to verify the load 
 
 ### Purpose
 
-All domains (poe2, mood, general) converge to a single `Event` type so that:
+All domains (poe2, mood, general, eng, worklog) converge to a single `Event` type so that:
 
 - Storage code (`append_jsonl`) needs no domain-specific branches.
 - History can be reconstructed from JSONL files alone, without domain knowledge.
@@ -112,7 +112,7 @@ All domains (poe2, mood, general) converge to a single `Event` type so that:
 | Field     | Type              | Description                                              |
 |-----------|-------------------|----------------------------------------------------------|
 | `ts`      | `str`             | ISO 8601 timestamp (UTC recommended)                     |
-| `domain`  | `str`             | Source domain — e.g. `"poe2"`, `"mood"`, `"general"`    |
+| `domain`  | `str`             | Source domain — MVP supported: `"poe2"`, `"mood"`, `"general"`, `"eng"`, `"worklog"` |
 | `payload` | `Dict[str, Any]`  | Domain-specific data; all values must be JSON-serializable |
 | `tags`    | `List[str]`       | Optional labels for filtering; use `[]` if not needed    |
 
@@ -123,19 +123,22 @@ from dataclasses import asdict
 from personal_mcp.core.event import Event
 
 event = Event(
-    ts="2026-03-03T12:00:00+00:00",
-    domain="poe2",
-    payload={"text": "ボスを倒した", "kind": "note"},
-    tags=["boss", "victory"],
+    ts="2026-03-04T11:00:00+00:00",
+    domain="eng",
+    payload={"text": "JSONL append-only方針を確認", "meta": {"kind": "milestone"}},
+    tags=["schema"],
 )
 
 asdict(event)
 # {
-#   "ts": "2026-03-03T12:00:00+00:00",
-#   "domain": "poe2",
-#   "payload": {"text": "ボスを倒した", "kind": "note"},
-#   "tags": ["boss", "victory"]
+#   "ts": "2026-03-04T11:00:00+00:00",
+#   "domain": "eng",
+#   "payload": {"text": "JSONL append-only方針を確認", "meta": {"kind": "milestone"}},
+#   "tags": ["schema"]
 # }
 ```
+
+`kind` はトップレベルの `payload` に置かず、`payload.meta.kind` に入れる。
+`payload.meta` 自体は省略可能（`poe2-watch` による自動記録など）。
 
 `asdict(event)` の結果はそのまま `append_jsonl(path, asdict(event))` に渡せる。

--- a/src/personal_mcp/core/event.py
+++ b/src/personal_mcp/core/event.py
@@ -7,16 +7,18 @@ from typing import Any, Dict, List
 
 @dataclass
 class Event:
-    """Common event schema for all domains (poe2, mood, general).
+    """Common event schema for all domains (poe2, mood, general, eng, worklog).
 
     All fields are JSON-serializable, so dataclasses.asdict(event)
     can be passed directly to append_jsonl without transformation.
 
     Fields:
         ts:      ISO 8601 timestamp string (UTC recommended)
-        domain:  Source domain, e.g. "poe2", "mood", "general"
-        payload: Domain-specific data; must contain only JSON-serializable values
-        tags:    Optional labels for filtering; use empty list if not needed
+        domain:  Source domain — MVP supported: "poe2", "mood", "general", "eng", "worklog"
+        payload: Domain-specific data; must contain only JSON-serializable values.
+                 Conventionally: {"text": ..., "meta": {"kind": ..., "source": ..., "ref": ...}}
+                 payload.meta is optional and can be omitted entirely.
+        tags:    Labels for filtering; use empty list if not needed
     """
 
     ts: str


### PR DESCRIPTION
## Summary
- clarify the README event contract for MVP-supported domains including eng/worklog
- align architecture docs with payload.meta.kind and the supported domain list
- update the Event docstring so implementation-adjacent schema notes match the docs

## Testing
- not run (docs/comment-only changes)

Closes #49