### PR TITLE
Restrict event-add domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ python -m personal_mcp.server poe2-watch --client-log /path/to/Client.txt
 - 区切りは必要時のみ `_`
 - `eng` は広いエンジニアリング活動（調査・設計・思考）、`worklog` は具体的な作業記録（セッション・進捗）として使い分ける
 
-`event-add` は技術上任意文字列を受け付けるが、MVP の明示サポート対象は上記のみとする。追加 domain は別 issue で定義する。
+`event-add` で受け付ける domain は上記 allowlist のみとする。追加 domain は別 issue で定義する。
 
 ### eng / worklog の最小 kind セット
 

--- a/src/personal_mcp/core/event.py
+++ b/src/personal_mcp/core/event.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List
 
 
+ALLOWED_DOMAINS = frozenset({"poe2", "mood", "general", "eng", "worklog"})
+
+
 @dataclass
 class Event:
     """Common event schema for all domains (poe2, mood, general, eng, worklog).

--- a/src/personal_mcp/tools/event.py
+++ b/src/personal_mcp/tools/event.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from personal_mcp.core.event import Event
+from personal_mcp.core.event import ALLOWED_DOMAINS, Event
 from personal_mcp.storage.jsonl import append_jsonl, read_jsonl
 
 
@@ -34,6 +34,9 @@ def event_add(
     meta: Optional[Dict[str, Any]] = None,
     data_dir: str = "data",
 ) -> Dict[str, Any]:
+    if domain not in ALLOWED_DOMAINS:
+        raise ValueError(f"unsupported domain: {domain}")
+
     payload: Dict[str, Any] = {"text": text}
     if meta:
         payload["meta"] = meta

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,46 @@ def test_event_add_event_list_e2e(tmp_path: Path) -> None:
     assert texts == {"alpha", "beta"}
 
 
+def test_event_add_accepts_eng_domain(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    events_path = data_dir / "events.jsonl"
+
+    _run("event-add", "eng event", "--domain", "eng", "--data-dir", str(data_dir))
+
+    record = json.loads(events_path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["domain"] == "eng"
+    assert record["payload"]["text"] == "eng event"
+
+
+def test_event_add_accepts_worklog_domain(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    events_path = data_dir / "events.jsonl"
+
+    _run("event-add", "worklog event", "--domain", "worklog", "--data-dir", str(data_dir))
+
+    record = json.loads(events_path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["domain"] == "worklog"
+    assert record["payload"]["text"] == "worklog event"
+
+
+def test_event_add_rejects_disallowed_domain_without_creating_file(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    events_path = data_dir / "events.jsonl"
+
+    result = _run(
+        "event-add",
+        "bad event",
+        "--domain",
+        "art",
+        "--data-dir",
+        str(data_dir),
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert not events_path.exists()
+
+
 # ---------------------------------------------------------------------------
 # 2. mood-add → event-list --domain mood
 # ---------------------------------------------------------------------------

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from personal_mcp.core.event import ALLOWED_DOMAINS
 from personal_mcp.tools.event import event_add, event_list
 
 
@@ -50,6 +51,32 @@ def test_event_add_appends_without_overwriting(data_dir: Path) -> None:
     record = json.loads(lines[1])
     assert record["domain"] == "mood"
     assert record["payload"]["text"] == "second"
+
+
+@pytest.mark.parametrize("domain", ["eng", "worklog"])
+def test_event_add_accepts_new_allowed_domains(data_dir: Path, domain: str) -> None:
+    path = data_dir / "events.jsonl"
+
+    event_add(domain=domain, text=f"{domain} entry", data_dir=str(data_dir))
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["domain"] == domain
+    assert record["payload"]["text"] == f"{domain} entry"
+
+
+def test_event_add_rejects_disallowed_domain_without_writing(data_dir: Path) -> None:
+    path = data_dir / "events.jsonl"
+
+    with pytest.raises(ValueError, match="unsupported domain: art"):
+        event_add(domain="art", text="bad domain", data_dir=str(data_dir))
+
+    assert not path.exists()
+
+
+def test_allowed_domains_keeps_existing_supported_domains() -> None:
+    assert {"poe2", "mood", "general"}.issubset(ALLOWED_DOMAINS)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an allowlist for supported event domains
- reject unsupported domains before writing to events.jsonl
- cover eng/worklog and invalid domain cases in unit and CLI tests

## Testing
- pytest tests/test_event.py tests/test_cli.py tests/test_poe2.py -v

## Risks
- invalid domain errors still surface via the existing CLI exception path

Closes #50