### PR TITLE
chore: add pre-commit and VSCode Ruff settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true
+  },
   "terminal.integrated.profiles.linux": {
     "Claude": { "path": "bash", "env": { "TERM_ROLE": "CLAUDE" } },
     "Codex":  { "path": "bash", "env": { "TERM_ROLE": "CODEX" } }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [
+    "pre-commit>=4.0",
     "ruff>=0.3",
     "pytest>=8.0",
 ]


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with `ruff --fix` and `ruff-format` hooks.
- Add workspace VSCode Python formatter settings to use Ruff and format on save.
- Add `pre-commit` to the `dev` optional dependency set.

## Developer setup
- `pre-commit install`
- `pre-commit run --all-files` (optional, useful once to normalize the tree)

## Intent
- Reduce local/CI drift so `ruff format --check` in CI is less likely to fail after local edits.

## ruff-pre-commit rev note
- Pinned `ruff-pre-commit` to `v0.15.4` to match the repo's current local Ruff version (`ruff 0.15.4`) and avoid version skew with existing CI usage.
