### PR TITLE
feat: tolerate legacy events missing v; emit v=1 for new events

### DIFF
--- a/src/personal_mcp/core/event.py
+++ b/src/personal_mcp/core/event.py
@@ -28,3 +28,4 @@ class Event:
     domain: str
     payload: Dict[str, Any]
     tags: List[str]
+    v: int = 1

--- a/src/personal_mcp/storage/jsonl.py
+++ b/src/personal_mcp/storage/jsonl.py
@@ -12,6 +12,17 @@ def append_jsonl(path: Path, record: Dict[str, Any]) -> None:
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
 
 
+def _normalize_event_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    if (
+        "v" not in record
+        and "ts" in record
+        and "domain" in record
+        and ("payload" in record or "data" in record)
+    ):
+        return {**record, "v": 1}
+    return record
+
+
 def read_jsonl(path: Path) -> List[Dict[str, Any]]:
     if not path.exists():
         return []
@@ -21,5 +32,5 @@ def read_jsonl(path: Path) -> List[Dict[str, Any]]:
             line = line.strip()
             if not line:
                 continue
-            out.append(json.loads(line))
+            out.append(_normalize_event_record(json.loads(line)))
     return out

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -88,6 +88,11 @@ def test_event_add_rejects_disallowed_domain_without_writing(data_dir: Path) -> 
     assert not path.exists()
 
 
+def test_event_add_writes_v1_field(data_dir: Path) -> None:
+    record = event_add(domain="general", text="versioned", data_dir=str(data_dir))
+    assert record["v"] == 1
+
+
 def test_allowed_domains_keeps_existing_supported_domains() -> None:
     assert {"poe2", "mood", "general"}.issubset(ALLOWED_DOMAINS)
 
@@ -150,6 +155,22 @@ def test_event_list_filter_by_date_excludes_other_days(data_dir: Path) -> None:
     result = event_list(date=day1, data_dir=str(data_dir))
     assert len(result) == 1
     assert result[0]["payload"]["text"] == "day1 mood"
+
+
+def test_event_list_tolerates_legacy_records_missing_v(data_dir: Path) -> None:
+    legacy_event = {
+        "ts": _TS_DAY2_A,
+        "domain": "general",
+        "payload": {"text": "legacy"},
+        "tags": [],
+    }
+    _write_events(data_dir / "events.jsonl", [legacy_event])
+
+    result = event_list(data_dir=str(data_dir))
+
+    assert len(result) == 1
+    assert result[0]["payload"]["text"] == "legacy"
+    assert result[0]["v"] == 1
 
 
 def test_event_list_filter_by_since(data_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- emit `v: 1` from the shared event writer path for newly appended events
- tolerate legacy event records missing `v` in the shared JSONL reader by treating them as `v=1` during reads
- add focused tests for legacy read tolerance and new event version emission

## Spec basis
- Issue #79
- `docs/event-contract-v1.md`

## Compatibility
- keep existing legacy log shape intact and readable
- avoid migrations or rewrites of existing `events.jsonl` records
- limit the change to writer-side version emission and reader-side tolerance so existing logs are not broken

## Tests
- verify `event_add()` returns a new record with `v: 1`
- verify a legacy record without `v` can still be loaded via `event_list()` and is treated as `v=1`
- `ruff format .`
- `ruff check .`
- `pytest`