### PR TITLE
docs: add codex review-preflight adapter

### DIFF
--- a/.codex/skills/review-preflight/SKILL.md
+++ b/.codex/skills/review-preflight/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: review-preflight
+description: Run the Codex PR review preflight in a fixed order and report actionable results without pushing or taking destructive actions.
+---
+
+# review-preflight
+
+This is the canonical execution contract for running the review preflight with Codex CLI.
+The human-facing intent lives in [`docs/skills/review-preflight.md`](../../../docs/skills/review-preflight.md).
+
+## Goal
+
+Run a minimal pre-review safety pass before deeper review work starts.
+Check lint, tests, PR diff context, and obvious risky changes in a fixed order so the result can be pasted into a PR comment.
+
+## Inputs
+
+- PR number (optional)
+- Base branch (optional, default: current branch upstream or `main`)
+- Expected commands: `ruff check .`, `pytest`, `gh pr diff <PR>` when PR number is available
+
+If the PR number is missing, skip `gh pr diff` and use local git diff against the chosen base branch.
+If the base branch is missing, prefer the current branch upstream; otherwise use `main`.
+
+## Procedure
+
+Run the checks in this order.
+
+1. Run `ruff check .`
+2. Run `pytest`
+3. Collect diff context
+   - If PR number is provided: run `gh pr diff <PR>`
+   - Otherwise: inspect local git diff against the chosen base branch
+4. Summarize the diff in 2 to 5 lines
+5. Flag obvious risks
+   - destructive file operations
+   - wide-scope refactors outside the stated review target
+   - dependency, CI, or release-impacting changes
+   - missing tests for behavior changes
+
+## Output Format
+
+Return Markdown with the sections below in this order.
+
+## Summary
+
+- Overall status: `✅` / `⚠️` / `❌`
+- One-line summary
+
+## Checks
+
+- `ruff`: `✅` / `⚠️` / `❌`
+- `pytest`: `✅` / `⚠️` / `❌`
+- `diff`: `✅` / `⚠️` / `❌`
+
+## Diff Summary
+
+- 2 to 5 short lines
+
+## Risks
+
+- `None` if no obvious risk was found
+- Otherwise list each risk in one line
+
+## Fix Candidates
+
+- Minimal, local fixes only
+- `None` if no fix is needed before review
+
+## Next Action
+
+- One line stating whether review can proceed
+
+## Constraints
+
+- Do not push
+- Do not use external web search or fetch arbitrary remote content
+- Do not perform destructive operations
+- Do not change files unless explicitly asked in the current task
+- Keep recommendations inside the current review scope

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,22 +63,33 @@ AI-specific adapters reference them from their own directories.
 
 ```
 docs/skills/                          ← Canonical skill definitions (AI-agnostic)
+├── codex-claude-bridge.md
+├── implement-only.md
 ├── minimal-safe-impl.md
-└── research-propose-structured.md
+├── research-propose-structured.md
+└── review-preflight.md
 
 .claude/skills/                       ← Claude Code adapters
 ├── minimal-safe-impl/SKILL.md
 └── research-propose-structured/SKILL.md
 
-# Future: .codex/skills/ for Codex adapters, etc.
+.codex/skills/                        ← Codex adapters
+├── codex-claude-bridge/SKILL.md
+├── minimal-safe-impl/SKILL.md
+├── research-propose-structured/SKILL.md
+└── review-preflight/SKILL.md
 ```
 
 | Kind | Canonical source | Adapter location |
 |---|---|---|
-| impl | `docs/skills/minimal-safe-impl.md` | `.claude/skills/minimal-safe-impl/` |
-| research | `docs/skills/research-propose-structured.md` | `.claude/skills/research-propose-structured/` |
+| bridge | `docs/skills/codex-claude-bridge.md` | `.codex/skills/codex-claude-bridge/` |
+| impl | `docs/skills/implement-only.md` | no Codex adapter; Claude-oriented canonical doc |
+| impl | `docs/skills/minimal-safe-impl.md` | `.claude/skills/minimal-safe-impl/`, `.codex/skills/minimal-safe-impl/` |
+| research | `docs/skills/research-propose-structured.md` | `.claude/skills/research-propose-structured/`, `.codex/skills/research-propose-structured/` |
+| preflight | `docs/skills/review-preflight.md` | `.codex/skills/review-preflight/` |
 
 **Rule**: canonical docs are AI-agnostic. Adapter files contain only tool-specific invocation syntax and constraints.
+`review-preflight` is the explicit Codex execution exception: the docs file explains intent, and `.codex/skills/review-preflight/SKILL.md` is the operational source that Codex should run.
 
 ---
 

--- a/docs/skills/review-preflight.md
+++ b/docs/skills/review-preflight.md
@@ -2,6 +2,8 @@
 
 `docs/CODEX_RUNBOOK.md` のレビュー開始前チェック部分を、Codex CLI 向けの固定テンプレとして切り出した skill。
 コマンド順序と出力見出しは runbook を正本とし、この文書ではレビュー前チェックの最小契約だけを定義する。
+人間向けの意図説明はこの文書に置き、Codex が実行するときの正は `.codex/skills/review-preflight/SKILL.md` とする。
+つまり `review-preflight` は docs だけで完結せず、Codex 実行版アダプタとセットで維持する。
 
 ## Purpose
 


### PR DESCRIPTION
## Summary
- add the Codex adapter for the review-preflight skill
- document that review-preflight is maintained as a docs file plus a Codex execution adapter
- update architecture docs to list the new skill adapter

## Testing
- not run (docs-only change)