### PR TITLE
docs: add codex-claude-bridge adapter sync

### DIFF
--- a/.codex/skills/codex-claude-bridge/SKILL.md
+++ b/.codex/skills/codex-claude-bridge/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: codex-claude-bridge
+description: Generate a stable branch name and Claude prompt by following the canonical spec in docs/skills/codex-claude-bridge.md. Use when Codex should prepare a maintainer-ready handoff to Claude without implementing changes.
+---
+
+# codex-claude-bridge
+
+This file is a thin Codex adapter.
+
+The canonical source of truth for this skill is [`docs/skills/codex-claude-bridge.md`](../../../docs/skills/codex-claude-bridge.md).
+
+Follow the behavior, rules, procedure, and output format defined in that document.
+
+When using this skill, read the canonical doc first and work according to it.
+
+Do not duplicate or redefine the detailed specification here. Update the docs file only when the skill behavior changes.

--- a/docs/skills/codex-claude-bridge.md
+++ b/docs/skills/codex-claude-bridge.md
@@ -2,7 +2,7 @@
 
 **種類**: bridge
 **正本**: このファイル（`docs/skills/codex-claude-bridge.md`）
-**Codex用アダプタ**: なし（MVP段階。`.codex/skills/` への adapter 追加は v2 以降で検討）
+**Codex用アダプタ**: `.codex/skills/codex-claude-bridge/SKILL.md`
 **Claude用アダプタ**: なし（このSkillは Codex CLI が実行する）
 
 ---

--- a/docs/skills/implement-only.md
+++ b/docs/skills/implement-only.md
@@ -3,6 +3,7 @@
 **種類**: impl
 **正本**: このファイル（`docs/skills/implement-only.md`）
 **Claude用アダプタ**: なし（`docs/skills/` を正本とし、この Issue では adapter を追加しない）
+**Codex対象**: いいえ（Claude の実装提案専用 skill）
 
 ---
 


### PR DESCRIPTION
## Summary
- add Codex adapter file for the codex-claude-bridge skill under .codex/skills
- update canonical codex-claude-bridge doc to reference the new adapter path
- clarify that implement-only is a Claude-only skill and not targeted for Codex

## Testing
- not run (docs-only changes)