### PR TITLE
feat: unify writer outputs to v1 event record

### DIFF
--- a/src/personal_mcp/core/event.py
+++ b/src/personal_mcp/core/event.py
@@ -1,31 +1,39 @@
 # src/personal_mcp/core/event.py
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 ALLOWED_DOMAINS = frozenset({"poe2", "mood", "general", "eng", "worklog"})
 
 
-@dataclass
-class Event:
-    """Common event schema for all domains (poe2, mood, general, eng, worklog).
+def build_v1_record(
+    *,
+    ts: str,
+    domain: str,
+    text: str,
+    tags: List[str],
+    kind: Optional[str] = None,
+    source: Optional[Any] = None,
+    ref: Optional[Any] = None,
+    extra_data: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a canonical Event Contract v1 record for new writes."""
+    data: Dict[str, Any] = {"text": text}
+    if extra_data:
+        data.update(extra_data)
 
-    All fields are JSON-serializable, so dataclasses.asdict(event)
-    can be passed directly to append_jsonl without transformation.
-
-    Fields:
-        ts:      ISO 8601 timestamp string (UTC recommended)
-        domain:  Source domain — MVP supported: "poe2", "mood", "general", "eng", "worklog"
-        payload: Domain-specific data; must contain only JSON-serializable values.
-                 Conventionally: {"text": ..., "meta": {"kind": ..., "source": ..., "ref": ...}}
-                 payload.meta is optional and can be omitted entirely.
-        tags:    Labels for filtering; use empty list if not needed
-    """
-
-    ts: str
-    domain: str
-    payload: Dict[str, Any]
-    tags: List[str]
-    v: int = 1
+    record: Dict[str, Any] = {
+        "ts": ts,
+        "domain": domain,
+        "data": data,
+        "tags": tags,
+        "v": 1,
+    }
+    if kind is not None:
+        record["kind"] = kind
+    if source is not None:
+        record["source"] = source
+    if ref is not None:
+        record["ref"] = ref
+    return record

--- a/src/personal_mcp/server.py
+++ b/src/personal_mcp/server.py
@@ -184,10 +184,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.cmd == "poe2-log-add":
         tags = [t for t in args.tags.split(",") if t]
         meta: Dict[str, Any] = json.loads(args.meta_json)
-        meta["kind"] = args.kind
         rec = event_add(
             domain="poe2",
             text=args.text,
+            kind=args.kind,
             tags=tags,
             meta=meta,
             data_dir=data_dir,

--- a/src/personal_mcp/tools/event.py
+++ b/src/personal_mcp/tools/event.py
@@ -1,12 +1,11 @@
 # src/personal_mcp/tools/event.py
 from __future__ import annotations
 
-from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from personal_mcp.core.event import ALLOWED_DOMAINS, Event
+from personal_mcp.core.event import ALLOWED_DOMAINS, build_v1_record
 from personal_mcp.storage.jsonl import append_jsonl, read_jsonl
 from personal_mcp.storage.path import resolve_data_dir
 
@@ -31,6 +30,7 @@ def _parse_since(since: Optional[str]) -> Optional[datetime]:
 def event_add(
     domain: str,
     text: str,
+    kind: Optional[str] = None,
     tags: Optional[List[str]] = None,
     meta: Optional[Dict[str, Any]] = None,
     data_dir: Optional[str] = None,
@@ -38,20 +38,23 @@ def event_add(
     if domain not in ALLOWED_DOMAINS:
         raise ValueError(f"unsupported domain: {domain}")
 
-    payload: Dict[str, Any] = {"text": text}
-    if meta:
-        payload["meta"] = meta
-
-    event = Event(
-        ts=_now_iso(),
-        domain=domain,
-        payload=payload,
-        tags=tags or [],
-    )
+    meta = meta or {}
+    source = meta.get("source")
+    ref = meta.get("ref")
+    extra_data = {k: v for k, v in meta.items() if k not in {"source", "ref"}}
 
     data_dir = resolve_data_dir(data_dir)
     path = Path(data_dir) / "events.jsonl"
-    record = asdict(event)
+    record = build_v1_record(
+        ts=_now_iso(),
+        domain=domain,
+        text=text,
+        tags=tags or [],
+        kind=kind,
+        source=source,
+        ref=ref,
+        extra_data=extra_data or None,
+    )
     append_jsonl(path, record)
     return record
 

--- a/src/personal_mcp/tools/poe2_client_watcher.py
+++ b/src/personal_mcp/tools/poe2_client_watcher.py
@@ -54,9 +54,9 @@ def watch_client_log(
                     event_add(
                         domain="poe2",
                         text=area,
+                        kind="area_transition",
                         tags=["auto"],
                         meta={
-                            "kind": "area_transition",
                             "source": "client_txt",
                             "raw": line.rstrip("\n"),
                         },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,7 +57,7 @@ def test_event_add_appends_incrementally(tmp_path: Path) -> None:
     lines = events_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     first_line = lines[0]
-    assert json.loads(first_line)["payload"]["text"] == "first event"
+    assert json.loads(first_line)["data"]["text"] == "first event"
 
     # 2回目
     _run("event-add", "second event", "--domain", "general", "--data-dir", str(data_dir))
@@ -65,7 +65,7 @@ def test_event_add_appends_incrementally(tmp_path: Path) -> None:
     assert len(lines) == 2
     # 既存行が書き換わっていないことを確認（追記のみ）
     assert lines[0] == first_line
-    assert json.loads(lines[1])["payload"]["text"] == "second event"
+    assert json.loads(lines[1])["data"]["text"] == "second event"
 
 
 def test_event_add_event_list_e2e(tmp_path: Path) -> None:
@@ -90,7 +90,7 @@ def test_event_add_accepts_eng_domain(tmp_path: Path) -> None:
 
     record = json.loads(events_path.read_text(encoding="utf-8").splitlines()[0])
     assert record["domain"] == "eng"
-    assert record["payload"]["text"] == "eng event"
+    assert record["data"]["text"] == "eng event"
 
 
 def test_event_add_accepts_worklog_domain(tmp_path: Path) -> None:
@@ -101,7 +101,7 @@ def test_event_add_accepts_worklog_domain(tmp_path: Path) -> None:
 
     record = json.loads(events_path.read_text(encoding="utf-8").splitlines()[0])
     assert record["domain"] == "worklog"
-    assert record["payload"]["text"] == "worklog event"
+    assert record["data"]["text"] == "worklog event"
 
 
 def test_event_add_rejects_disallowed_domain_without_creating_file(tmp_path: Path) -> None:
@@ -139,7 +139,7 @@ def test_env_var_data_dir_is_used(tmp_path: Path) -> None:
     lines = events_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     record = json.loads(lines[0])
-    assert record["payload"]["text"] == "env test"
+    assert record["data"]["text"] == "env test"
     assert record["domain"] == "general"
     assert _repo_data_jsonl_snapshot() == before
 
@@ -167,7 +167,7 @@ def test_explicit_data_dir_overrides_env_var(tmp_path: Path) -> None:
     lines = events_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     record = json.loads(lines[0])
-    assert record["payload"]["text"] == "explicit test"
+    assert record["data"]["text"] == "explicit test"
     assert not (env_dir / "events.jsonl").exists()
     assert _repo_data_jsonl_snapshot() == before
 
@@ -194,7 +194,7 @@ def test_writes_to_tmp_not_repo_data_dir(tmp_path: Path) -> None:
     lines = events_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     record = json.loads(lines[0])
-    assert record["payload"]["text"] == "repo isolation test"
+    assert record["data"]["text"] == "repo isolation test"
 
     # repo/data/ 側に新規 JSONL が作られていない
     assert _repo_data_jsonl_snapshot() == before
@@ -263,7 +263,7 @@ def test_poe2_log_add_appends_to_events_jsonl(tmp_path: Path) -> None:
     first_line = lines[0]
     record = json.loads(first_line)
     assert record["domain"] == "poe2"
-    assert record["payload"]["text"] == "farming T17 map"
+    assert record["data"]["text"] == "farming T17 map"
 
     # 2回目（追記のみ）
     _run("poe2-log-add", "boss defeated", "--data-dir", str(data_dir))
@@ -271,7 +271,7 @@ def test_poe2_log_add_appends_to_events_jsonl(tmp_path: Path) -> None:
     assert len(lines) == 2
     # 既存行が書き換わっていないことを確認
     assert lines[0] == first_line
-    assert json.loads(lines[1])["payload"]["text"] == "boss defeated"
+    assert json.loads(lines[1])["data"]["text"] == "boss defeated"
 
 
 def test_poe2_log_add_domain_is_poe2(tmp_path: Path) -> None:
@@ -283,4 +283,4 @@ def test_poe2_log_add_domain_is_poe2(tmp_path: Path) -> None:
 
     record = json.loads(events_path.read_text(encoding="utf-8").splitlines()[0])
     assert record["domain"] == "poe2"
-    assert record["payload"]["meta"]["kind"] == "note"
+    assert record["kind"] == "note"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -36,7 +36,7 @@ def test_event_add_creates_jsonl_with_one_line(data_dir: Path) -> None:
     assert len(lines) == 1
     record = json.loads(lines[0])
     assert record["domain"] == "poe2"
-    assert record["payload"]["text"] == "test"
+    assert record["data"]["text"] == "test"
 
 
 def test_event_add_uses_env_data_dir_when_omitted(monkeypatch, tmp_path: Path) -> None:
@@ -49,7 +49,7 @@ def test_event_add_uses_env_data_dir_when_omitted(monkeypatch, tmp_path: Path) -
     lines = path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     record = json.loads(lines[0])
-    assert record["payload"]["text"] == "test"
+    assert record["data"]["text"] == "test"
 
 
 def test_event_add_appends_without_overwriting(data_dir: Path) -> None:
@@ -63,7 +63,7 @@ def test_event_add_appends_without_overwriting(data_dir: Path) -> None:
     assert json.loads(lines[0]) == {"dummy": True}
     record = json.loads(lines[1])
     assert record["domain"] == "mood"
-    assert record["payload"]["text"] == "second"
+    assert record["data"]["text"] == "second"
 
 
 @pytest.mark.parametrize("domain", ["eng", "worklog"])
@@ -76,7 +76,7 @@ def test_event_add_accepts_new_allowed_domains(data_dir: Path, domain: str) -> N
     assert len(lines) == 1
     record = json.loads(lines[0])
     assert record["domain"] == domain
-    assert record["payload"]["text"] == f"{domain} entry"
+    assert record["data"]["text"] == f"{domain} entry"
 
 
 def test_event_add_rejects_disallowed_domain_without_writing(data_dir: Path) -> None:
@@ -91,6 +91,41 @@ def test_event_add_rejects_disallowed_domain_without_writing(data_dir: Path) -> 
 def test_event_add_writes_v1_field(data_dir: Path) -> None:
     record = event_add(domain="general", text="versioned", data_dir=str(data_dir))
     assert record["v"] == 1
+
+
+def test_event_add_writes_v1_shape_without_payload(data_dir: Path) -> None:
+    record = event_add(domain="general", text="shape", data_dir=str(data_dir))
+    assert "payload" not in record
+    assert record["data"]["text"] == "shape"
+
+
+def test_event_add_promotes_source_ref_and_keeps_other_meta_in_data(data_dir: Path) -> None:
+    record = event_add(
+        domain="poe2",
+        text="entered hideout",
+        kind="area_transition",
+        meta={
+            "source": "client_txt",
+            "ref": "line:1",
+            "raw": "[SCENE] Set Source [Hideout]",
+        },
+        data_dir=str(data_dir),
+    )
+    assert record["kind"] == "area_transition"
+    assert record["source"] == "client_txt"
+    assert record["ref"] == "line:1"
+    assert record["data"]["raw"] == "[SCENE] Set Source [Hideout]"
+
+
+def test_event_add_does_not_promote_meta_kind_without_kind_arg(data_dir: Path) -> None:
+    record = event_add(
+        domain="poe2",
+        text="meta kind",
+        meta={"kind": "from-meta"},
+        data_dir=str(data_dir),
+    )
+    assert "kind" not in record
+    assert record["data"]["kind"] == "from-meta"
 
 
 def test_allowed_domains_keeps_existing_supported_domains() -> None:
@@ -227,19 +262,19 @@ def test_mood_add_writes_mood_domain(data_dir: Path) -> None:
     assert len(lines) == 1
     record = json.loads(lines[0])
     assert record["domain"] == "mood"
-    assert record["payload"]["text"] == "少し疲れた"
+    assert record["data"]["text"] == "少し疲れた"
 
 
-def test_mood_add_no_numeric_score_in_payload(data_dir: Path) -> None:
+def test_mood_add_no_numeric_score_in_data(data_dir: Path) -> None:
     from personal_mcp.server import main
 
     main(["mood-add", "まあまあ", "--data-dir", str(data_dir)])
 
     path = data_dir / "events.jsonl"
     record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
-    payload = record.get("payload", {})
-    numeric_keys = [k for k, v in payload.items() if isinstance(v, (int, float))]
-    assert numeric_keys == [], f"numeric keys found in payload: {numeric_keys}"
+    data = record.get("data", {})
+    numeric_keys = [k for k, v in data.items() if isinstance(v, (int, float))]
+    assert numeric_keys == [], f"numeric keys found in data: {numeric_keys}"
 
 
 def test_mood_add_with_tags(data_dir: Path) -> None:

--- a/tests/test_poe2.py
+++ b/tests/test_poe2.py
@@ -18,7 +18,7 @@ def test_poe2_log_add_writes_to_events_jsonl(data_dir: Path) -> None:
     assert len(lines) == 1
     record = json.loads(lines[0])
     assert record["domain"] == "poe2"
-    assert record["payload"]["text"] == "farming T17 map"
+    assert record["data"]["text"] == "farming T17 map"
 
 
 def test_poe2_log_add_appends_not_overwrites(data_dir: Path) -> None:
@@ -34,12 +34,12 @@ def test_poe2_log_add_appends_not_overwrites(data_dir: Path) -> None:
     assert record["domain"] == "poe2"
 
 
-def test_poe2_log_add_stores_kind_in_payload(data_dir: Path) -> None:
+def test_poe2_log_add_stores_kind_at_top_level(data_dir: Path) -> None:
     main(["poe2-log-add", "note text", "--kind", "note", "--data-dir", str(data_dir)])
 
     path = data_dir / "events.jsonl"
     record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
-    assert record["payload"]["meta"]["kind"] == "note"
+    assert record["kind"] == "note"
 
 
 def test_poe2_log_add_stores_tags(data_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- switch writer path from legacy payload output to canonical v1 record output
- add shared build_v1_record builder and route event-add / mood-add / poe2-log-add through it
- preserve watcher semantics by passing kind=area_transition explicitly and promoting only source / ref
- update raw JSON assertions in tests from payload to data and top-level kind
- add tests for promotion rules and for non-promotion of meta.kind without kind arg

## Verification
- pytest -q tests/test_event.py tests/test_poe2.py tests/test_cli.py tests/test_jsonl.py

Closes #92