### PR TITLE
feat: add issue dependency DAG generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,30 @@ src/personal_mcp/
 
 機能追加は事前にIssueで議論してください。
 
+### Issue 依存 DAG の生成
+
+Issue 間の依存関係を抽出して DOT / Mermaid 形式で可視化するスクリプトです。
+
+**依存**: Python 3.10+（標準ライブラリのみ）。PNG 出力には graphviz (`dot` コマンド) が必要です。
+
+```bash
+# stdin から実行（gh CLI 必須）
+gh issue list --json number,title,body | python scripts/issue_dag.py
+
+# JSON ファイルから実行
+gh issue list --json number,title,body > issues.json
+python scripts/issue_dag.py issues.json
+
+# PNG も同時に生成（graphviz 必須）
+python scripts/issue_dag.py issues.json --png
+
+# 出力先を指定する場合
+python scripts/issue_dag.py issues.json --out /tmp/dag
+```
+
+出力: `dag.dot`（Graphviz）、`dag.mmd`（Mermaid）、`dag.png`（`--png` 時のみ）。
+Mermaid はそのまま GitHub Markdown の Mermaid コードブロックに貼れます。
+
 ---
 
 ## ライセンス

--- a/scripts/issue_dag.py
+++ b/scripts/issue_dag.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Extract issue dependency DAG from gh issue list JSON.
+
+Usage:
+    gh issue list --json number,title,body | python scripts/issue_dag.py
+    python scripts/issue_dag.py issues.json
+    python scripts/issue_dag.py issues.json --png
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_EXPLICIT = re.compile(r"(?:blocked by|depends on|requires)\s+#(\d+)", re.IGNORECASE)
+_BARE_REF = re.compile(r"#(\d+)")
+
+
+def _escape_label(text: str) -> str:
+    """Escape backslash then double-quote for DOT / Mermaid label strings."""
+    return text.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def extract_edges(issues: list[dict]) -> set[tuple[int, int]]:
+    """Return directed edges (src, dst) where src depends on dst."""
+    numbers = {issue["number"] for issue in issues}
+    edges: set[tuple[int, int]] = set()
+    for issue in issues:
+        src = issue["number"]
+        body = issue.get("body") or ""
+        explicit_refs: set[int] = set()
+        for m in _EXPLICIT.finditer(body):
+            ref = int(m.group(1))
+            if ref != src and ref in numbers:
+                explicit_refs.add(ref)
+                edges.add((src, ref))
+        for m in _BARE_REF.finditer(body):
+            ref = int(m.group(1))
+            if ref != src and ref in numbers and ref not in explicit_refs:
+                edges.add((src, ref))
+    return edges
+
+
+def build_dot(issues: list[dict], edges: set[tuple[int, int]]) -> str:
+    lines = ["digraph issues {", "    rankdir=LR;"]
+    for issue in sorted(issues, key=lambda i: i["number"]):
+        number = issue["number"]
+        label = _escape_label(issue.get("title", ""))
+        lines.append(f'    {number} [label="#{number}: {label}"];')
+    for src, dst in sorted(edges):
+        lines.append(f"    {src} -> {dst};")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def build_mmd(issues: list[dict], edges: set[tuple[int, int]]) -> str:
+    lines = ["flowchart LR"]
+    for issue in sorted(issues, key=lambda i: i["number"]):
+        number = issue["number"]
+        label = _escape_label(issue.get("title", ""))
+        lines.append(f'    i{number}["#{number}: {label}"]')
+    for src, dst in sorted(edges):
+        lines.append(f"    i{src} --> i{dst}")
+    return "\n".join(lines)
+
+
+def render_png(dot_path: Path, png_path: Path) -> None:
+    """Render dot_path to png_path via graphviz dot.
+
+    Exit codes:
+      1  - graphviz dot command not found (FileNotFoundError)
+      N  - dot exited with non-zero code N
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["dot", "-Tpng", str(dot_path), "-o", str(png_path)],
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        print(
+            "error: graphviz `dot` command not found."
+            " Install graphviz (e.g. `apt install graphviz` or `brew install graphviz`)"
+            " and retry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if result.returncode == 0:
+        print(f"Written: {png_path}")
+        return
+
+    print(f"graphviz error: {result.stderr.decode()}", file=sys.stderr)
+    sys.exit(result.returncode)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate issue dependency DAG from gh issue list JSON"
+    )
+    parser.add_argument("input", nargs="?", help="JSON file path (default: stdin)")
+    parser.add_argument("--out", default=".", help="Output directory (default: current dir)")
+    parser.add_argument(
+        "--png",
+        action="store_true",
+        help="Also render dag.png via graphviz dot (requires graphviz installed)",
+    )
+    args = parser.parse_args()
+
+    if args.input:
+        data = json.loads(Path(args.input).read_text())
+    else:
+        data = json.load(sys.stdin)
+
+    issues = data if isinstance(data, list) else []
+    edges = extract_edges(issues)
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    dot_path = out / "dag.dot"
+    dot_path.write_text(build_dot(issues, edges))
+    print(f"Written: {dot_path}")
+
+    mmd_path = out / "dag.mmd"
+    mmd_path.write_text(build_mmd(issues, edges))
+    print(f"Written: {mmd_path}")
+
+    if args.png:
+        render_png(dot_path, out / "dag.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_issue_dag.py
+++ b/tests/test_issue_dag.py
@@ -1,0 +1,149 @@
+"""Tests for scripts/issue_dag.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from issue_dag import (  # noqa: E402
+    _escape_label,
+    build_dot,
+    build_mmd,
+    extract_edges,
+    render_png,
+)
+
+_ISSUES = [
+    {"number": 1, "title": "Base", "body": ""},
+    {"number": 2, "title": "Blocked", "body": "blocked by #1"},
+    {"number": 3, "title": "Depends", "body": "depends on #1 and requires #2"},
+    {"number": 4, "title": "BareRef", "body": "see #3 for context"},
+    {"number": 5, "title": "Self", "body": "self ref #5 and external #999"},
+]
+
+
+def test_explicit_blocked_by() -> None:
+    assert (2, 1) in extract_edges(_ISSUES)
+
+
+def test_explicit_depends_on() -> None:
+    assert (3, 1) in extract_edges(_ISSUES)
+
+
+def test_explicit_requires() -> None:
+    assert (3, 2) in extract_edges(_ISSUES)
+
+
+def test_bare_ref() -> None:
+    assert (4, 3) in extract_edges(_ISSUES)
+
+
+def test_self_reference_excluded() -> None:
+    edges = extract_edges(_ISSUES)
+    assert all(src != dst for src, dst in edges)
+
+
+def test_external_issue_number_excluded() -> None:
+    known = {i["number"] for i in _ISSUES}
+    edges = extract_edges(_ISSUES)
+    assert all(dst in known for _, dst in edges)
+
+
+def test_no_edges_emitted_for_body_with_no_refs() -> None:
+    edges = extract_edges(_ISSUES)
+    assert all(src != 1 for src, _ in edges)
+
+
+def test_duplicate_edges_excluded() -> None:
+    issues = [
+        {"number": 1, "title": "A", "body": ""},
+        {"number": 2, "title": "B", "body": "blocked by #1 and also see #1"},
+    ]
+    edges = extract_edges(issues)
+    assert len([edge for edge in edges if edge == (2, 1)]) == 1
+
+
+def test_build_dot_structure() -> None:
+    issues = [
+        {"number": 1, "title": "Alpha", "body": ""},
+        {"number": 2, "title": "Beta", "body": "blocked by #1"},
+    ]
+    dot = build_dot(issues, extract_edges(issues))
+    assert "digraph issues {" in dot
+    assert "2 -> 1;" in dot
+    assert "#1: Alpha" in dot
+
+
+def test_build_mmd_structure() -> None:
+    issues = [
+        {"number": 1, "title": "Alpha", "body": ""},
+        {"number": 2, "title": "Beta", "body": "blocked by #1"},
+    ]
+    mmd = build_mmd(issues, extract_edges(issues))
+    assert "flowchart LR" in mmd
+    assert "i2 --> i1" in mmd
+
+
+def test_escape_label_double_quote() -> None:
+    assert _escape_label('say "hello"') == 'say \\"hello\\"'
+
+
+def test_escape_label_backslash() -> None:
+    assert _escape_label("path\\to\\file") == "path\\\\to\\\\file"
+
+
+def test_escape_label_backslash_before_quote_no_double_escape() -> None:
+    assert _escape_label('\\"') == '\\\\\\"'
+
+
+def test_build_dot_escapes_title() -> None:
+    issues = [{"number": 1, "title": 'Fix "bug" in path\\util', "body": ""}]
+    dot = build_dot(issues, set())
+    assert '\\"' in dot
+    assert "\\\\" in dot
+
+
+def test_build_mmd_escapes_title() -> None:
+    issues = [{"number": 1, "title": 'Fix "bug" in path\\util', "body": ""}]
+    mmd = build_mmd(issues, set())
+    assert '\\"' in mmd
+    assert "\\\\" in mmd
+
+
+def test_render_png_dot_not_found_exits_1(tmp_path: Path) -> None:
+    dot_path = tmp_path / "dag.dot"
+    dot_path.write_text("digraph {}")
+
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        with pytest.raises(SystemExit) as exc:
+            render_png(dot_path, tmp_path / "dag.png")
+    assert exc.value.code == 1
+
+
+def test_render_png_dot_failure_exits_with_dot_returncode(tmp_path: Path) -> None:
+    dot_path = tmp_path / "dag.dot"
+    dot_path.write_text("digraph {}")
+
+    mock_result = MagicMock()
+    mock_result.returncode = 2
+    mock_result.stderr = b"syntax error near line 1"
+
+    with patch("subprocess.run", return_value=mock_result):
+        with pytest.raises(SystemExit) as exc:
+            render_png(dot_path, tmp_path / "dag.png")
+    assert exc.value.code == 2
+
+
+def test_render_png_success_does_not_raise(tmp_path: Path) -> None:
+    dot_path = tmp_path / "dag.dot"
+    dot_path.write_text("digraph {}")
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch("subprocess.run", return_value=mock_result):
+        render_png(dot_path, tmp_path / "dag.png")


### PR DESCRIPTION
## Summary
- add `scripts/issue_dag.py` to extract issue dependencies from issue-list JSON and generate `dag.dot` / `dag.mmd`
- support optional `--png` rendering via Graphviz with explicit error handling and exit codes
- add focused tests for edge extraction, escaping, and png rendering paths
- document usage in README developer section

## Validation
- `ruff check scripts/issue_dag.py tests/test_issue_dag.py`
- `pytest tests/test_issue_dag.py -v`

Closes #101