### PR TITLE
feat: add copy-friendly issue DAG edge list output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
+.PHONY: guide-sync guide-check issue-dag-list
+
+REPO ?= wakadorimk2/personal-mcp-core
+LIMIT ?= 200
+OUT ?= /tmp/issue-dag
+ISSUES_JSON ?= /tmp/issues.json
+WITH_TITLE ?=
+
 guide-sync:
 	cp AI_GUIDE.md src/personal_mcp/AI_GUIDE.md
 
 guide-check:
 	diff AI_GUIDE.md src/personal_mcp/AI_GUIDE.md || (echo "AI_GUIDE out of sync" && exit 1)
+
+issue-dag-list:
+	gh issue list --repo "$(REPO)" --limit "$(LIMIT)" --json number,title,body > "$(ISSUES_JSON)"
+	python scripts/issue_dag.py "$(ISSUES_JSON)" --list $(if $(WITH_TITLE),--list-with-title,) --out "$(OUT)"

--- a/README.md
+++ b/README.md
@@ -342,8 +342,16 @@ python scripts/issue_dag.py issues.json --png
 # 依存エッジ一覧を CLI に出力（コピー向け）
 python scripts/issue_dag.py issues.json --list
 
+# Makefile ターゲットで実行
+# 既定: REPO=wakadorimk2/personal-mcp-core, LIMIT=200, ISSUES_JSON=/tmp/issues.json, OUT=/tmp/issue-dag
+make issue-dag-list
+make issue-dag-list WITH_TITLE=1
+
 # 出力先を指定する場合
 python scripts/issue_dag.py issues.json --out /tmp/dag
+make issue-dag-list OUT=/tmp/dag LIMIT=100
+make issue-dag-list ISSUES_JSON=/tmp/my-issues.json
+python scripts/issue_dag.py issues.json --list-with-title
 ```
 
 出力: `dag.dot`（Graphviz）、`dag.mmd`（Mermaid）、`dag.png`（`--png` 時のみ）。

--- a/scripts/issue_dag.py
+++ b/scripts/issue_dag.py
@@ -72,6 +72,15 @@ def build_edge_list(edges: set[tuple[int, int]]) -> str:
     return "\n".join(f"#{src} -> #{dst}" for src, dst in sorted(edges))
 
 
+def build_edge_list_with_title(issues: list[dict], edges: set[tuple[int, int]]) -> str:
+    """Build edge list with issue titles for quick overview on CLI."""
+    title_by_number = {issue["number"]: (issue.get("title") or "") for issue in issues}
+    return "\n".join(
+        f"#{src} ({title_by_number.get(src, '')}) -> #{dst} ({title_by_number.get(dst, '')})"
+        for src, dst in sorted(edges)
+    )
+
+
 def render_png(dot_path: Path, png_path: Path) -> None:
     """Render dot_path to png_path via graphviz dot.
 
@@ -119,6 +128,11 @@ def main() -> None:
         action="store_true",
         help="Print copy-friendly edge list to stdout (#src -> #dst)",
     )
+    parser.add_argument(
+        "--list-with-title",
+        action="store_true",
+        help="Print edge list with issue titles for quick overview",
+    )
     args = parser.parse_args()
 
     if args.input:
@@ -140,7 +154,9 @@ def main() -> None:
     mmd_path.write_text(build_mmd(issues, edges))
     print(f"Written: {mmd_path}")
 
-    if args.list:
+    if args.list_with_title:
+        print(build_edge_list_with_title(issues, edges))
+    elif args.list:
         print(build_edge_list(edges))
 
     if args.png:

--- a/tests/test_issue_dag.py
+++ b/tests/test_issue_dag.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 from issue_dag import (  # noqa: E402
     _escape_label,
     build_edge_list,
+    build_edge_list_with_title,
     build_dot,
     build_mmd,
     extract_edges,
@@ -93,6 +94,20 @@ def test_build_edge_list_structure() -> None:
     edges = {(3, 1), (3, 2), (4, 3)}
     result = build_edge_list(edges)
     assert result.splitlines() == ["#3 -> #1", "#3 -> #2", "#4 -> #3"]
+
+
+def test_build_edge_list_with_title_structure() -> None:
+    issues = [
+        {"number": 1, "title": "Alpha", "body": ""},
+        {"number": 2, "title": "Beta", "body": ""},
+        {"number": 3, "title": "Gamma", "body": ""},
+    ]
+    edges = {(3, 1), (3, 2)}
+    result = build_edge_list_with_title(issues, edges)
+    assert result.splitlines() == [
+        "#3 (Gamma) -> #1 (Alpha)",
+        "#3 (Gamma) -> #2 (Beta)",
+    ]
 
 
 def test_escape_label_double_quote() -> None:


### PR DESCRIPTION
## Summary
- add `--list` option to `scripts/issue_dag.py` for copy-friendly output (`#src -> #dst`)
- add test coverage for edge-list output
- update README usage examples

## Validation
- `pytest -q tests/test_issue_dag.py`
- `python scripts/issue_dag.py /tmp/issues.json --list --out /tmp/issue-dag`
