### PR TITLE
docs: establish Event Contract v1 as single source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,12 @@ python -m personal_mcp.server poe2-watch --client-log /path/to/Client.txt
 
 ### v1 record フィールド契約
 
-イベントの保存契約は [Event Contract v1](./docs/event-contract-v1.md) に従う。
+イベントの保存契約は **[Event Contract v1](./docs/event-contract-v1.md)（正典）** に従う。
 
-| フィールド | 必須/推奨 | 説明 |
-| --- | --- | --- |
-| `v` | 必須 | schema バージョン（`1` 固定） |
-| `ts` | 必須 | タイムスタンプ（ISO 8601 タイムゾーン付き）。内部保存は UTC を原則とする |
-| `domain` | 必須 | ドメイン識別子（下記 MVP 許可リストを参照） |
-| `kind` | 必須 | イベント種別（`note` / `session` / `milestone` など）。[kind taxonomy](./docs/kind-taxonomy-v1.md) を参照 |
-| `data` | 必須 | ドメイン固有データ。本文は原則 `data.text`（無い場合は best-effort で扱う） |
-| `tags` | 推奨 | タグリスト（省略可） |
-| `source` | 推奨 | データ取得元（`"manual"` など） |
-| `ref` | 推奨 | 参照先（Issue 番号など） |
+**必須フィールド**: `v`（`1` 固定）、`ts`（ISO 8601 タイムゾーン付き）、`domain`（下記 MVP 許可リスト参照）、`kind`（[kind taxonomy](./docs/kind-taxonomy-v1.md) 参照）、`data`。
+**推奨フィールド**: `tags`、`source`、`ref`（いずれも省略可）。
 
-> **注記**: 既存 JSONL に残る legacy record（`payload` 形式）との対応方針は [docs/event-contract-v1.md](./docs/event-contract-v1.md) の mapping / tolerance を参照。
+フィールド定義の詳細・legacy record（`payload` 形式）との対応方針・reader tolerance は正典を参照。
 
 ### タイムスタンプ方針
 
@@ -131,6 +123,8 @@ python -m personal_mcp.server poe2-watch --client-log /path/to/Client.txt
 
 ### イベント例
 
+代表例（詳細・追加例は [Event Contract v1](./docs/event-contract-v1.md) を参照）:
+
 #### eng / note
 
 ```json
@@ -143,53 +137,6 @@ python -m personal_mcp.server poe2-watch --client-log /path/to/Client.txt
     "text": "MCP adapterの調査メモ"
   },
   "tags": ["research"],
-  "source": "manual"
-}
-```
-
-#### worklog / session
-
-```json
-{
-  "v": 1,
-  "ts": "2026-03-04T19:00:00+09:00",
-  "domain": "worklog",
-  "kind": "session",
-  "data": {
-    "text": "Issue #23の切り分け"
-  },
-  "tags": ["debug"],
-  "ref": "#23"
-}
-```
-
-#### eng / milestone
-
-```json
-{
-  "v": 1,
-  "ts": "2026-03-04T20:00:00+09:00",
-  "domain": "eng",
-  "kind": "milestone",
-  "data": {
-    "text": "JSONL append-only方針を確認"
-  },
-  "tags": ["schema"]
-}
-```
-
-#### worklog / note
-
-```json
-{
-  "v": 1,
-  "ts": "2026-03-04T21:00:00+09:00",
-  "domain": "worklog",
-  "kind": "note",
-  "data": {
-    "text": "レビュー前に再現手順を整理"
-  },
-  "tags": ["review"],
   "source": "manual"
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,7 @@ external requirements. The placeholder prints context length to verify the load 
 
 ## Event schema
 
+> Authoritative spec: **[docs/event-contract-v1.md](./event-contract-v1.md)**.
 > Builder: `src/personal_mcp/core/event.py` (`build_v1_record`).
 > Issue #100 で writer migration を実施し、v1 record への移行を進めた。
 
@@ -128,16 +129,20 @@ All domains (poe2, mood, general, eng, worklog) converge to a single `Event` typ
 
 ### v1 record fields
 
-| Field    | Type              | Description                                                                                      |
-|----------|-------------------|--------------------------------------------------------------------------------------------------|
-| `v`      | `int`             | Schema version. Always `1` for new records                                                       |
-| `ts`     | `str`             | ISO 8601 timestamp with timezone offset (UTC recommended)                                        |
-| `domain` | `str`             | Source domain — MVP: `"poe2"`, `"mood"`, `"general"`, `"eng"`, `"worklog"`                      |
-| `kind`   | `str`             | Event kind (`"note"`, `"session"`, `"milestone"`, etc.). Required by v1 contract |
-| `data`   | `Dict[str, Any]`  | Domain-specific data; `data.text` is the canonical text field                                    |
-| `tags`   | `List[str]`       | Optional labels for filtering                                                                    |
-| `source` | `str`             | Optional. Data origin (`"manual"`, `"watcher"`, etc.)                                            |
-| `ref`    | `str`             | Optional. Reference to issue number or external ID                                               |
+フィールドの正規定義は **[docs/event-contract-v1.md](./event-contract-v1.md)（正典）** を参照。実装上の型対応:
+
+| Field    | Python type       |
+|----------|-------------------|
+| `v`      | `int`             |
+| `ts`     | `str`             |
+| `domain` | `str`             |
+| `kind`   | `str`             |
+| `data`   | `Dict[str, Any]`  |
+| `tags`   | `List[str]`       |
+| `source` | `str`             |
+| `ref`    | `str`             |
+
+`tags` / `source` / `ref` は optional（省略可）。required keys は正典の「Required top-level keys」に従う。
 
 ### JSONL example
 

--- a/docs/event-contract-v1.md
+++ b/docs/event-contract-v1.md
@@ -1,6 +1,9 @@
 # Event Contract v1
 
 > **Note**
+> **この文書は Event Contract v1 の authoritative spec（正典）である。**
+> README.md・docs/architecture.md はこの正典への参照を保持し、契約本文を独立複製しない。
+>
 > この文書は Event Contract v1 を定義する（Issue #94 cleanup により仕様変更はない）。
 > Issue #100 の writer migration により、新規書き込みはすべて v1 形式で保存される。
 > 既存 JSONL に残る legacy record（`payload` 形式）は reader が正規化する（Section D 参照）。


### PR DESCRIPTION
## Summary
- declare `docs/event-contract-v1.md` as the authoritative Event Contract v1 spec
- reduce duplicated contract prose in `README.md` and `docs/architecture.md` to summary + references
- keep required/optional key semantics explicit in architecture docs (`tags`/`source`/`ref` are optional)

## Validation
- `ruff check .`
- `pytest`

Closes #115