### PR TITLE
docs(skills): split issue-create and issue-project-meta responsibilities

### DIFF
--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-create
-description: issue-draft で確定した title/body・ラベル候補・owner/repo を受け取り、gh label list によるラベル確認・重複チェック・gh issue create コマンド生成・Projects/relationship メタデータ反映・作成結果記録の手順を標準化する。
+description: issue-draft で確定した title/body・ラベル候補・owner/repo を受け取り、gh label list によるラベル確認・重複チェック・gh issue create コマンド生成・作成結果記録の手順を標準化する。Projects/relationship メタデータ更新は issue-project-meta に委譲する。
 argument-hint: "[issue-draft-output-or-title body labels owner/repo]"
 disable-model-invocation: true
 ---

--- a/.claude/skills/issue-project-meta/SKILL.md
+++ b/.claude/skills/issue-project-meta/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: issue-project-meta
+description: issue-create 完了後に、Projects の列・優先度・依存関係を反映する手順を標準化する。Status/Priority 更新・blocked-by/sub-issue 追加・根拠記録・未実施時 TODO 記録を担う。
+argument-hint: "[issue-url issue-number owner/repo project-number [blocked-by] [sub-issues]]"
+disable-model-invocation: true
+---
+
+# issue-project-meta（Claude アダプタ）
+
+> このファイルは Claude Code 用のアダプタです。
+> **正本（AI非依存）**: [`docs/skills/issue-project-meta.md`](../../../docs/skills/issue-project-meta.md)
+> 振る舞い・Rules・Procedure・Output テンプレは正本を参照してください。
+> このファイルには Claude 固有の呼び出し構文と引数だけを記載します。
+
+## Claude 固有の呼び出し
+
+- 入力は `$ARGUMENTS`（`issue-create` Output B の引き渡し情報 + project_number）
+- 開始前に必ず正本を読み、Rules に従う
+- 正本を読む前にコマンドを出力してはならない
+- 実際のコマンド実行はしない（コマンド案の生成のみ）
+
+## Invocation Examples
+
+- `/issue-project-meta "issue_url: https://github.com/wakadorimk2/personal-mcp-core/issues/106 issue_number: 106 owner: wakadorimk2 repo: personal-mcp-core project_number: 1"`
+- `/issue-project-meta "issue_url: ... blocked_by: 104 sub_issues: 107"`

--- a/.codex/skills/issue-create/SKILL.md
+++ b/.codex/skills/issue-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-create
-description: Create a GitHub Issue from issue-draft output, following the canonical spec in docs/skills/issue-create.md. Use when Codex should execute gh label list, duplicate check, gh issue create, fill Projects/relationship metadata, and record the resulting URL/number.
+description: Create a GitHub Issue from issue-draft output, following the canonical spec in docs/skills/issue-create.md. Use when Codex should execute gh label list, duplicate check, gh issue create, and record the resulting URL/number. Projects/relationship metadata is handled by issue-project-meta.
 ---
 
 # issue-create

--- a/.codex/skills/issue-project-meta/SKILL.md
+++ b/.codex/skills/issue-project-meta/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: issue-project-meta
+description: Update Projects metadata (Status, Priority, blocked-by, sub-issue) after a GitHub Issue has been created. Use when Codex should execute gh project item-add, gh project item-edit, and relationship API calls, then record the result.
+---
+
+# issue-project-meta
+
+This file is a thin Codex adapter.
+
+The canonical source of truth for this skill is [`docs/skills/issue-project-meta.md`](../../../docs/skills/issue-project-meta.md).
+
+Follow the behavior, rules, procedure, and output format defined in that document.
+
+When using this skill, read the canonical doc first and work according to it.
+
+Do not duplicate or redefine the detailed specification here. Update the docs file only when the skill behavior changes.

--- a/docs/skills/issue-create.md
+++ b/docs/skills/issue-create.md
@@ -12,7 +12,6 @@
 `issue-draft` で確定した title/body・ラベル候補・repo情報を受け取り、
 `gh` コマンドで GitHub Issue を作成するための手順を標準化する。
 ラベル存在確認・重複チェックを必須とし、作成後の URL/番号記録を義務付ける。
-さらに Projects / relationship などのメタデータを可能な限り埋める。
 
 ---
 
@@ -43,7 +42,7 @@
 3. **作成後の URL/番号記録を必須とする** — `gh issue create` の出力から URL と番号を取得し、必ず記録・出力する
 4. **再実行可能なコマンド形式を維持する** — 同じ入力から同じコマンドが生成できる形式にする（body はファイル経由 `--body-file` を推奨）
 5. **実際のコマンド実行はしない** — コピペ可能なコマンド案を生成するのみ（実行は Codex 側）
-6. **メタデータは可能な限り反映する** — Projects / relationship（blocked-by / sub-issue など）の入力がある場合は、Issue 作成後に反映用コマンドを必ず出力する
+6. **Issue 作成後メタデータは別 skill に委譲する** — Projects / relationship（blocked-by / sub-issue など）の反映は `issue-project-meta` の責務とする
 
 ---
 
@@ -56,9 +55,6 @@
 | `labels` | 任意 | 適用候補ラベル名のリスト（例: `["bug", "enhancement"]`） |
 | `owner` | 必須 | GitHub リポジトリオーナー名（例: `wakadorimk2`） |
 | `repo` | 必須 | GitHub リポジトリ名（例: `personal-mcp-core`） |
-| `projects` | 任意 | 追加先 Project の識別子リスト（Project 番号や ID） |
-| `blocked_by` | 任意 | 依存元 Issue 番号のリスト（この Issue が block される側） |
-| `sub_issues` | 任意 | 子 Issue の番号リスト（親子関係を付ける場合） |
 
 ---
 
@@ -68,7 +64,7 @@
 2. **ラベル存在確認（必須）** — `gh label list` コマンドを生成し、候補ラベルの照合手順を示す
 3. **重複チェック（疑いがある場合）** — タイトル類似度が高い場合は `gh issue list --search` コマンドを生成し、結果確認を求める
 4. **`gh issue create` コマンドを生成する**（Output A）
-5. **メタデータ反映コマンドを生成する**（Output B）
+5. **issue-project-meta への引き渡し情報を示す**（Output B）
 6. **作成後の記録手順を示す**（Output C）
 
 ---
@@ -128,43 +124,22 @@ gh issue create \
 
 ---
 
-## Output B: メタデータ反映コマンド（任意だが推奨）
+## Output B: issue-project-meta への引き渡し（任意だが推奨）
 
-> Projects / relationship の入力がある場合は、以下をそのまま実行できる形式で提示する。
-> 対象入力がない項目は省略してよい。
+> Projects / relationship などのメタデータ更新は `issue-project-meta` に委譲する。
+> `issue-create` は引き渡しに必要な最小情報を出力する。
 
-### B-1: Project 追加
+```text
+## issue-project-meta への引き渡し
 
-```bash
-# 例: 作成済み Issue #<number> を Project に追加する
-gh issue edit <number> \
-  --repo <owner>/<repo> \
-  --add-project "<project>"
+- issue_url: https://github.com/<owner>/<repo>/issues/<number>
+- issue_number: <number>
+- owner: <owner>
+- repo: <repo>
+- project_number: <project-number>    # なければ「なし」
+- blocked_by: <issue-number-list>     # なければ「なし」
+- sub_issues: <issue-number-list>     # なければ「なし」
 ```
-
-### B-2: relationship 追加（blocked by）
-
-```bash
-# 例: Issue #<number> が Issue #<blocked_by_number> に block される関係を追加
-printf '{"issue_id":<blocked_by_issue_id>}' > /tmp/blocked-by.json
-gh api -X POST \
-  repos/<owner>/<repo>/issues/<number>/dependencies/blocked_by \
-  --input /tmp/blocked-by.json
-```
-
-### B-3: relationship 追加（sub-issue）
-
-```bash
-# 例: Issue #<sub_issue_number> を Issue #<number> の sub-issue として追加
-printf '{"sub_issue_id":<sub_issue_number>}' > /tmp/sub-issue.json
-gh api -X POST \
-  repos/<owner>/<repo>/issues/<number>/sub_issues \
-  --input /tmp/sub-issue.json
-```
-
-> 注意:
-> - relationship API の利用可否・payload は GitHub 側仕様/権限に依存する。実行前に利用可能性を確認すること。
-> - Issue 番号しかない場合、`<blocked_by_issue_id>` への解決手順（GraphQL / API 参照）は別途運用ルールに従う。
 
 ---
 
@@ -179,8 +154,6 @@ gh api -X POST \
 - **番号**: #<number>
 - **title**: <title>
 - **labels**: <適用されたラベル一覧（なければ「なし」）>
-- **projects**: <追加した Project 一覧（なければ「なし」）>
-- **relationship**: <追加した関係（blocked_by/sub_issue など。なければ「なし」）>
 - **作成日時**: <YYYY-MM-DD HH:MM>
 ```
 
@@ -212,15 +185,8 @@ gh issue create \
   --label "documentation" \
   --label "enhancement"
 
-# 4. メタデータ反映（例）
-gh issue edit <created-issue-number> \
-  --repo wakadorimk2/personal-mcp-core \
-  --add-project "Team Board"
-
-printf '{"sub_issue_id":103}' > /tmp/sub-issue.json
-gh api -X POST \
-  repos/wakadorimk2/personal-mcp-core/issues/<created-issue-number>/sub_issues \
-  --input /tmp/sub-issue.json
+# 4. issue-project-meta へ引き渡し
+# issue_url, issue_number, owner, repo, project_number を渡してメタ更新は issue-project-meta で実施
 ```
 
 ### 作成結果記録（例）
@@ -232,8 +198,6 @@ gh api -X POST \
 - **番号**: #105
 - **title**: add issue-create skill spec
 - **labels**: documentation, enhancement
-- **projects**: Team Board
-- **relationship**: sub_issue #103
 - **作成日時**: 2026-03-05 10:00
 ```
 
@@ -281,7 +245,7 @@ gh issue create --title "issue-create skill"
 gh issue create --title "..." --body-file body.md
 ```
 
-**修正**: 実行後に Output B のフォーマットで URL と番号を必ず記録・出力する。
+**修正**: 実行後に Output C のフォーマットで URL と番号を必ず記録・出力する。
 
 ### ダメ例 6: body をインラインで渡す
 
@@ -303,7 +267,6 @@ gh issue create --title "..." --body "## Goal\n..."
 | owner/repo が未指定 | 必須情報として owner と repo の入力を求める |
 | ラベル候補が存在しない | そのラベルを外したコマンドを生成し、ラベルなし作成を提案する |
 | 重複 Issue が見つかった | 重複候補の URL/番号を列挙し、人間に作成可否を確認する |
-| Projects / relationship の入力が不足 | Issue は作成し、記録フォーマットに `なし` を明記して追記TODOを残す |
 
 ---
 
@@ -315,4 +278,4 @@ gh issue create --title "..." --body "## Goal\n..."
 - 作成後の URL/番号記録を省略する
 - `gh issue create` を Claude 自身が実行する
 - body を `--body` フラグに直接インライン記述する
-- Projects / relationship の入力があるのに反映コマンドを省略する
+- issue-create の出力に Project / relationship 更新コマンドを混在させる

--- a/docs/skills/issue-project-meta.md
+++ b/docs/skills/issue-project-meta.md
@@ -1,0 +1,155 @@
+# issue-project-meta
+
+**種類**: post-create
+**正本**: このファイル（`docs/skills/issue-project-meta.md`）
+**Claude用アダプタ**: `.claude/skills/issue-project-meta/SKILL.md`
+**Codex用アダプタ**: `.codex/skills/issue-project-meta/SKILL.md`
+
+---
+
+## Mission
+
+Issue 作成後に、Projects の列・優先度・依存関係を一貫した手順で反映する。
+Project 側の設定値と Issue 本文の依存記述を一致させ、記録テンプレートを残す。
+
+---
+
+## Dependencies
+
+- blocked by #105
+
+---
+
+## 前提条件（必須）
+
+- **`gh issue create` が完了し、Issue URL / 番号が確定していること** — 作成前に本 skill を実行しない
+- **`issue-create` Output B（引き渡し情報）が手元にあること** — `issue_url`・`issue_number`・`owner`・`repo`・`project_number` を確認する
+- **対象 Project が存在していること** — 未作成の Project への追加は本 skill の範囲外
+
+> 上記が未充足の場合は、未充足理由を記録して終了する（実行を強行しない）。
+
+---
+
+## Rules（絶対）
+
+1. **Issue 作成後にのみ実施する** — `gh issue create` より前に Project メタ更新を行わない
+2. **列 / 優先度の根拠を記録する** — なぜその値にしたかを 1 行で残す
+3. **依存関係は Issue 本文と Project 側を整合させる** — 乖離がある場合は更新対象を明記してそろえる
+4. **実行不能時は未実施理由を残す** — TODO と理由を記録し、未完了を隠さない
+5. **コマンドは再実行可能形式で提示する** — プレースホルダを明示し、コピペ可能な形で出力する
+
+---
+
+## Inputs
+
+| 項目 | 必須 | 説明 |
+|---|---|---|
+| `issue_url` | 必須 | 作成済み Issue URL |
+| `issue_number` | 必須 | 作成済み Issue 番号（例: `106`） |
+| `owner` | 必須 | GitHub オーナー |
+| `repo` | 必須 | GitHub リポジトリ |
+| `project_number` | 必須 | 対象 Project 番号 |
+| `project_id` | 任意 | 対象 Project ID（未取得なら手順内で取得） |
+| `item_id` | 任意 | Project に追加済み item の ID（未取得なら追加後に取得） |
+| `status_field_id` | 任意 | Status フィールド ID |
+| `status_option_id` | 任意 | 設定する Status オプション ID |
+| `priority_field_id` | 任意 | Priority フィールド ID |
+| `priority_option_id` | 任意 | 設定する Priority オプション ID |
+| `blocked_by_issue_id` | 任意 | blocked-by 先の GraphQL issue_id |
+| `sub_issue_number` | 任意 | sub-issue として追加する Issue 番号 |
+
+---
+
+## Procedure（作業手順）
+
+1. Issue が作成済みであることを確認する
+2. 必要な ID を取得する（`project_id`・`item_id`・`field_id`・`option_id`）
+3. Project へ item を追加する
+4. Status / Priority を必要に応じて更新する
+5. blocked-by / sub-issue 関係を必要に応じて追加する
+6. 反映結果と根拠を Output B テンプレートで記録する
+
+---
+
+## Output A: コピペ可能な反映コマンド
+
+```bash
+# --- 0) 必要な ID を取得する（未取得の場合のみ実行）---
+
+# project_id 取得
+gh project list --owner <owner> --format json \
+  --jq '.projects[] | select(.number == <project-number>) | .id'
+
+# item_id 取得（Project に Issue を追加した後で実行）
+gh project item-list <project-number> --owner <owner> --format json \
+  --jq '.items[] | select(.content.number == <issue-number>) | .id'
+
+# Status / Priority フィールド一覧取得（field_id と option_id を確認）
+gh project field-list <project-number> --owner <owner> --format json
+# → 出力から "Status" / "Priority" の id と options[].id を読み取る
+
+# 1) Project に Issue を追加
+gh project item-add <project-number> --owner <owner> --url <issue-url>
+
+# 2) Status 更新（任意）
+gh project item-edit --id <item-id> --project-id <project-id> --field-id <status-field-id> --single-select-option-id <status-option-id>
+
+# 3) Priority 更新（任意）
+gh project item-edit --id <item-id> --project-id <project-id> --field-id <priority-field-id> --single-select-option-id <priority-option-id>
+
+# 4) blocked-by 追加（任意）
+printf '{"issue_id":<blocked_by_issue_id>}' > /tmp/blocked-by.json
+gh api -X POST repos/<owner>/<repo>/issues/<issue-number>/dependencies/blocked_by --input /tmp/blocked-by.json
+
+# 5) sub-issue 追加（任意）
+printf '{"sub_issue_id":<sub_issue_number>}' > /tmp/sub-issue.json
+gh api -X POST repos/<owner>/<repo>/issues/<issue-number>/sub_issues --input /tmp/sub-issue.json
+```
+
+> **注意（sub-issues / blocked-by API）**: 上記エンドポイントは GitHub の Sub-issues 機能に依存する。
+> ベータ・プレビュー段階では形式が変わる場合があるため、実行前に公式ドキュメントと照合すること。
+> 実行できない場合は Output B の TODO 欄に記録して終了する。
+
+---
+
+## Output B: 反映記録テンプレート
+
+```md
+- Project: <project-name>
+- Status: <status-value>
+- Priority: <priority-value>
+- Dependencies: blocked by #<number> / sub-issue #<number>
+- Rationale: <列/優先度の根拠を1行>
+- Result: <done | partial | todo>
+- TODO: <未実施があれば記載。なければ「なし」>
+```
+
+---
+
+## 失敗時の扱い
+
+- 権限不足・ID 未解決で実行できない場合は、未実施項目を TODO として残す
+- 依存関係が本文と不一致の場合は、どちらを正としたかを明記する
+
+---
+
+## 前提未充足時の対応
+
+| 状況 | 対応 |
+|---|---|
+| Issue 未作成（番号が確定していない） | 実行を中断し、`issue-create` を先に完了するよう伝える |
+| `project_number` が未指定 | Project 追加・メタ更新をスキップし、TODO として記録する |
+| フィールド ID / オプション ID が取得できない | `gh project field-list` を再実行して手動確認を求める |
+| blocked-by API が利用不可 | Issue 本文の `## Dependencies` 欄を手動更新し、TODO に記録する |
+| sub-issue API が利用不可 | 対象 Issue にコメントで親 Issue 番号を記載し、TODO に記録する |
+
+---
+
+## 禁止
+
+- `gh issue create` より前に本 skill を実行する
+- `project_id` / `item_id` を推測で埋めてコマンドを生成する
+- Status / Priority の根拠を記録せずに更新する
+- 未実施の項目を Output B に書かず終了する
+- blocked-by / sub-issue を Issue 本文と Project 側で乖離したまま放置する
+- 本 skill 内で `gh issue create` を再実行する


### PR DESCRIPTION
## Summary
- add new canonical skill `issue-project-meta` and Codex/Claude adapters
- move Projects/relationship update responsibilities out of `issue-create`
- keep `issue-create` focused on issue creation and handoff payload output
- align handoff fields between `issue-create` and `issue-project-meta`
- fix stale reference: URL/number record format is `Output C` in `issue-create`

## Validation
- pre-commit hooks triggered on commit (ruff hooks skipped; docs-only changes)
- manual review of cross-doc field consistency (`issue_number`, `owner`, `repo`, `project_number`)

Closes #106