### PR TITLE
chore: update VS Code terminal/workspace settings

### DIFF
--- a/.vscode/personal-mcp-core.code-workspace
+++ b/.vscode/personal-mcp-core.code-workspace
@@ -1,0 +1,38 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		}
+	],
+	"settings": {
+		"terminal.integrated.enablePersistentSessions": true,
+		"terminal.integrated.profiles.linux": {
+			"Claude": {
+				"path": "bash",
+				"icon": "claude",
+				"color": "terminal.ansiYellow",
+				"overrideName": true,
+				"env": {
+					"TERM_ROLE": "CLAUDE"
+				},
+				"args": [
+					"-lc",
+					"cd ~/personal-mcp-core && source .venv/bin/activate && claude"
+				]
+			},
+			"Codex": {
+				"path": "bash",
+				"icon": "openai",
+				"color": "terminal.ansiWhite",
+				"overrideName": true,
+				"env": {
+					"TERM_ROLE": "CODEX"
+				},
+				"args": [
+					"-lc",
+					"cd ~/personal-mcp-core && source .venv/bin/activate && codex"
+				]
+			}
+		}
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,34 @@
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSave": true
   },
+  "python.terminal.activateEnvironment": false,
+  "terminal.integrated.enablePersistentSessions": true,
   "terminal.integrated.profiles.linux": {
-    "Claude": { "path": "bash", "env": { "TERM_ROLE": "CLAUDE" } },
-    "Codex":  { "path": "bash", "env": { "TERM_ROLE": "CODEX" } }
+    "Claude": {
+      "path": "bash",
+      "icon": "claude",
+      "color": "terminal.ansiYellow",
+      "overrideName": true,
+      "env": {
+        "TERM_ROLE": "CLAUDE"
+      },
+      "args": [
+        "-lc",
+        "cd ~/personal-mcp-core && source .venv/bin/activate && claude"
+      ]
+    },
+    "Codex": {
+      "path": "bash",
+      "icon": "openai",
+      "color": "terminal.ansiWhite",
+      "overrideName": true,
+      "env": {
+        "TERM_ROLE": "CODEX"
+      },
+      "args": [
+        "-lc",
+        "cd ~/personal-mcp-core && source .venv/bin/activate && codex"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- update .vscode/settings.json with Claude/Codex integrated terminal profiles
- add persistent terminal session and disable Python auto-activation in terminal
- add .vscode/personal-mcp-core.code-workspace for opening the repo with preconfigured terminal profiles

## Testing
- not run (VS Code settings only)