### PR TITLE
chore: update VSCode profile launch scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
+.vscode/*.code-workspace
 
 # Ruff stuff:
 .ruff_cache/

--- a/.vscode/bin/claude.sh
+++ b/.vscode/bin/claude.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [ -f .venv/bin/activate ]; then
+  source .venv/bin/activate
+fi
+
+exec claude

--- a/.vscode/bin/codex.sh
+++ b/.vscode/bin/codex.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [ -f .venv/bin/activate ]; then
+  source .venv/bin/activate
+fi
+
+exec codex

--- a/.vscode/personal-mcp-core.code-workspace
+++ b/.vscode/personal-mcp-core.code-workspace
@@ -17,7 +17,7 @@
 				},
 				"args": [
 					"-lc",
-					"cd ~/personal-mcp-core && source .venv/bin/activate && claude"
+					"cd ${workspaceFolder} && source .venv/bin/activate && claude"
 				]
 			},
 			"Codex": {
@@ -30,7 +30,7 @@
 				},
 				"args": [
 					"-lc",
-					"cd ~/personal-mcp-core && source .venv/bin/activate && codex"
+					"cd ${workspaceFolder} && source .venv/bin/activate && codex"
 				]
 			}
 		}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,10 +14,7 @@
       "env": {
         "TERM_ROLE": "CLAUDE"
       },
-      "args": [
-        "-lc",
-        "cd ~/personal-mcp-core && source .venv/bin/activate && claude"
-      ]
+      "args": ["-lc", ".vscode/bin/claude.sh"]
     },
     "Codex": {
       "path": "bash",
@@ -27,10 +24,7 @@
       "env": {
         "TERM_ROLE": "CODEX"
       },
-      "args": [
-        "-lc",
-        "cd ~/personal-mcp-core && source .venv/bin/activate && codex"
-      ]
+      "args": ["-lc", ".vscode/bin/codex.sh"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add launcher scripts under \.vscode/bin for Claude/Codex terminal profiles
- switch workspace/settings terminal args to use \ and scripts instead of hard-coded ~/personal-mcp-core paths
- ignore \.vscode/*.code-workspace in gitignore to avoid profile-local workspace noise

## Validation
- not run (configuration-only change)

## Notes
- expected behavior is unchanged except path resolution becomes repository-root based