### PR TITLE
feat: add manual GitHub activity sync to events

### DIFF
--- a/src/personal_mcp/server.py
+++ b/src/personal_mcp/server.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 from personal_mcp.adapters.mcp_server import get_system_context
 from personal_mcp.storage.path import resolve_data_dir
 from personal_mcp.tools.event import event_add, event_list
+from personal_mcp.tools.github_sync import github_sync
 from personal_mcp.tools.poe2_client_watcher import watch_client_log
 
 
@@ -122,6 +123,14 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_list.add_argument("--data-dir", default=None)
     p_list.add_argument("--json", action="store_true")
 
+    p_ghsync = sub.add_parser("github-sync", help="sync GitHub user events to events.jsonl")
+    p_ghsync.add_argument("--username", required=True, help="GitHub username")
+    p_ghsync.add_argument(
+        "--token", default=None, help="GitHub API token (or GITHUB_TOKEN env var)"
+    )
+    p_ghsync.add_argument("--data-dir", default=None)
+    p_ghsync.add_argument("--json", action="store_true")
+
     args = parser.parse_args(argv)
     data_dir = resolve_data_dir(getattr(args, "data_dir", None))
 
@@ -222,6 +231,20 @@ def main(argv: Optional[List[str]] = None) -> int:
                 tags_str = ",".join(r.get("tags") or [])
                 text = r.get("data", {}).get("text", "")
                 print(f"{r.get('ts', '?')} [{kind}] ({tags_str}) {text}")
+        return 0
+
+    if args.cmd == "github-sync":
+        token = args.token or os.environ.get("GITHUB_TOKEN")
+        result = github_sync(
+            username=args.username,
+            token=token,
+            data_dir=data_dir,
+        )
+        if args.json:
+            print(json.dumps(result, ensure_ascii=False))
+        else:
+            sv, sk, fl = result["saved"], result["skipped"], result["failed"]
+            print(f"saved: {sv}, skipped: {sk}, failed: {fl}")
         return 0
 
     return 1

--- a/src/personal_mcp/tools/github_sync.py
+++ b/src/personal_mcp/tools/github_sync.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from personal_mcp.core.event import build_v1_record
+from personal_mcp.storage.jsonl import append_jsonl, read_jsonl
+from personal_mcp.storage.path import resolve_data_dir
+
+
+_SKIP_TYPES: frozenset = frozenset({"WatchEvent", "PublicEvent", "MemberEvent"})
+
+
+def _fetch_github_events(username: str, token: Optional[str]) -> List[Dict[str, Any]]:
+    """Fetch user events from GitHub API (first page, up to 100)."""
+    url = f"https://api.github.com/users/{username}/events?per_page=100"
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _normalize_ts(ts: str) -> str:
+    """Normalize GitHub 'Z' suffix to explicit '+00:00' offset."""
+    return ts.replace("Z", "+00:00")
+
+
+def _map_event_to_record(gh_event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Map a GitHub API event to an Event Contract v1 record.
+
+    Returns None for event types that should be skipped.
+    """
+    event_type = gh_event.get("type", "")
+    if event_type in _SKIP_TYPES:
+        return None
+
+    payload = gh_event.get("payload", {})
+    repo = gh_event.get("repo", {}).get("name", "")
+    ts = _normalize_ts(gh_event.get("created_at", ""))
+    event_id = str(gh_event.get("id", ""))
+
+    extra_data: Dict[str, Any] = {"github_event_id": event_id}
+    ref: Optional[str] = None
+    kind: str = "note"
+    text: str = ""
+
+    if event_type == "PushEvent":
+        commits = payload.get("commits", [])
+        branch = payload.get("ref", "").replace("refs/heads/", "")
+        text = f"pushed {len(commits)} commit(s) to {repo} ({branch})"
+        kind = "artifact"
+        if commits:
+            ref = commits[0].get("sha", "")[:7]
+    elif event_type == "IssuesEvent":
+        action = payload.get("action", "")
+        issue = payload.get("issue", {})
+        ref = f"#{issue.get('number', '')}"
+        text = f"{action} issue: {issue.get('title', '')}"
+        kind = "milestone" if action == "closed" else "note"
+    elif event_type == "PullRequestEvent":
+        action = payload.get("action", "")
+        pr = payload.get("pull_request", {})
+        ref = f"PR#{pr.get('number', '')}"
+        merged = pr.get("merged", False)
+        title = pr.get("title", "")
+        if action == "closed" and merged:
+            text = f"merged PR: {title}"
+            kind = "milestone"
+        elif action == "closed":
+            text = f"closed PR: {title}"
+            kind = "milestone"
+        else:
+            text = f"{action} PR: {title}"
+            kind = "artifact"
+    elif event_type == "CreateEvent":
+        ref_type = payload.get("ref_type", "")
+        ref_name = payload.get("ref", "")
+        text = f"created {ref_type}: {ref_name} on {repo}"
+        kind = "artifact"
+    else:
+        text = f"{event_type} on {repo}"
+        kind = "note"
+
+    return build_v1_record(
+        ts=ts,
+        domain="eng",
+        text=text,
+        tags=[],
+        kind=kind,
+        source="github",
+        ref=ref,
+        extra_data=extra_data,
+    )
+
+
+def _load_existing_github_event_ids(path: Path) -> Set[str]:
+    """Return the set of github_event_id values already stored."""
+    if not path.exists():
+        return set()
+    ids: Set[str] = set()
+    for r in read_jsonl(path):
+        if r.get("source") == "github":
+            eid = r.get("data", {}).get("github_event_id")
+            if eid:
+                ids.add(str(eid))
+    return ids
+
+
+def github_sync(
+    username: str,
+    token: Optional[str] = None,
+    data_dir: Optional[str] = None,
+) -> Dict[str, int]:
+    """Fetch GitHub user events and append new ones to events.jsonl.
+
+    Returns {"saved": int, "skipped": int, "failed": int}.
+    """
+    resolved = resolve_data_dir(data_dir)
+    path = Path(resolved) / "events.jsonl"
+
+    existing_ids = _load_existing_github_event_ids(path)
+    try:
+        gh_events = _fetch_github_events(username, token)
+    except Exception:
+        return {"saved": 0, "skipped": 0, "failed": 1}
+
+    if not isinstance(gh_events, list):
+        return {"saved": 0, "skipped": 0, "failed": 1}
+
+    saved = skipped = failed = 0
+    for gh_event in gh_events:
+        event_id = str(gh_event.get("id", ""))
+        if event_id in existing_ids:
+            skipped += 1
+            continue
+        try:
+            record = _map_event_to_record(gh_event)
+            if record is None:
+                skipped += 1
+                continue
+            append_jsonl(path, record)
+            existing_ids.add(event_id)
+            saved += 1
+        except Exception:
+            failed += 1
+
+    return {"saved": saved, "skipped": skipped, "failed": failed}

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from personal_mcp.tools.github_sync import (
+    _load_existing_github_event_ids,
+    _map_event_to_record,
+    _normalize_ts,
+    github_sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_events(path: Path, events: list) -> None:
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+def _push_event(event_id: str = "100") -> Dict[str, Any]:
+    return {
+        "id": event_id,
+        "type": "PushEvent",
+        "repo": {"name": "user/repo"},
+        "created_at": "2026-03-07T10:00:00Z",
+        "payload": {
+            "ref": "refs/heads/main",
+            "commits": [{"sha": "abc1234567890"}],
+        },
+    }
+
+
+def _issues_event(action: str = "closed", event_id: str = "200") -> Dict[str, Any]:
+    return {
+        "id": event_id,
+        "type": "IssuesEvent",
+        "repo": {"name": "user/repo"},
+        "created_at": "2026-03-07T11:00:00Z",
+        "payload": {
+            "action": action,
+            "issue": {"number": 42, "title": "Fix the bug"},
+        },
+    }
+
+
+def _watch_event(event_id: str = "999") -> Dict[str, Any]:
+    return {
+        "id": event_id,
+        "type": "WatchEvent",
+        "repo": {"name": "user/repo"},
+        "created_at": "2026-03-07T10:00:00Z",
+        "payload": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _normalize_ts
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_ts_replaces_z() -> None:
+    assert _normalize_ts("2026-03-07T10:00:00Z") == "2026-03-07T10:00:00+00:00"
+
+
+def test_normalize_ts_leaves_explicit_offset_unchanged() -> None:
+    ts = "2026-03-07T10:00:00+09:00"
+    assert _normalize_ts(ts) == ts
+
+
+# ---------------------------------------------------------------------------
+# _map_event_to_record (FR-02)
+# ---------------------------------------------------------------------------
+
+
+def test_map_push_event_produces_v1_record() -> None:
+    record = _map_event_to_record(_push_event())
+    assert record is not None
+    assert record["v"] == 1
+    assert record["domain"] == "eng"
+    assert record["kind"] == "artifact"
+    assert record["source"] == "github"
+    assert "pushed" in record["data"]["text"]
+    assert record["data"]["github_event_id"] == "100"
+    assert record["ref"] == "abc1234"
+    assert record["ts"] == "2026-03-07T10:00:00+00:00"
+
+
+def test_map_issue_closed_is_milestone() -> None:
+    record = _map_event_to_record(_issues_event(action="closed"))
+    assert record is not None
+    assert record["kind"] == "milestone"
+    assert record["ref"] == "#42"
+    assert "closed" in record["data"]["text"]
+    assert "Fix the bug" in record["data"]["text"]
+
+
+def test_map_issue_opened_is_note() -> None:
+    record = _map_event_to_record(_issues_event(action="opened"))
+    assert record is not None
+    assert record["kind"] == "note"
+
+
+def test_map_pr_merged_is_milestone() -> None:
+    gh = {
+        "id": "300",
+        "type": "PullRequestEvent",
+        "repo": {"name": "user/repo"},
+        "created_at": "2026-03-07T12:00:00Z",
+        "payload": {
+            "action": "closed",
+            "pull_request": {"number": 7, "title": "Add feature", "merged": True},
+        },
+    }
+    record = _map_event_to_record(gh)
+    assert record is not None
+    assert record["kind"] == "milestone"
+    assert record["ref"] == "PR#7"
+    assert "merged" in record["data"]["text"]
+
+
+def test_map_watch_event_returns_none() -> None:
+    assert _map_event_to_record(_watch_event()) is None
+
+
+# ---------------------------------------------------------------------------
+# _load_existing_github_event_ids
+# ---------------------------------------------------------------------------
+
+
+def test_load_ids_returns_empty_when_file_missing(data_dir: Path) -> None:
+    assert _load_existing_github_event_ids(data_dir / "events.jsonl") == set()
+
+
+def test_load_ids_returns_only_github_source_ids(data_dir: Path) -> None:
+    path = data_dir / "events.jsonl"
+    github_event = {
+        "v": 1,
+        "ts": "2026-03-07T10:00:00+00:00",
+        "domain": "eng",
+        "kind": "artifact",
+        "data": {"text": "x", "github_event_id": "abc"},
+        "tags": [],
+        "source": "github",
+    }
+    manual_event = {
+        "v": 1,
+        "ts": "2026-03-07T10:00:00+00:00",
+        "domain": "eng",
+        "kind": "note",
+        "data": {"text": "manual entry"},
+        "tags": [],
+        "source": "manual",
+    }
+    _write_events(path, [github_event, manual_event])
+    assert _load_existing_github_event_ids(path) == {"abc"}
+
+
+# ---------------------------------------------------------------------------
+# github_sync (FR-01, FR-03, FR-04)
+# ---------------------------------------------------------------------------
+
+
+def test_github_sync_saves_new_event(data_dir: Path, monkeypatch) -> None:
+    import personal_mcp.tools.github_sync as mod
+
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+
+    result = github_sync(username="user", data_dir=str(data_dir))
+
+    assert result == {"saved": 1, "skipped": 0, "failed": 0}
+    lines = (data_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["data"]["github_event_id"] == "100"
+
+
+def test_github_sync_skips_duplicate(data_dir: Path, monkeypatch) -> None:
+    import personal_mcp.tools.github_sync as mod
+
+    path = data_dir / "events.jsonl"
+    existing = {
+        "v": 1,
+        "ts": "2026-03-07T10:00:00+00:00",
+        "domain": "eng",
+        "kind": "artifact",
+        "data": {"text": "already saved", "github_event_id": "100"},
+        "tags": [],
+        "source": "github",
+    }
+    _write_events(path, [existing])
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+
+    result = github_sync(username="user", data_dir=str(data_dir))
+
+    assert result["saved"] == 0
+    assert result["skipped"] == 1
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_github_sync_skips_low_signal_event(data_dir: Path, monkeypatch) -> None:
+    import personal_mcp.tools.github_sync as mod
+
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_watch_event()])
+
+    result = github_sync(username="user", data_dir=str(data_dir))
+
+    assert result["saved"] == 0
+    assert result["skipped"] == 1
+    assert not (data_dir / "events.jsonl").exists()
+
+
+def test_github_sync_summary_counts(data_dir: Path, monkeypatch) -> None:
+    import personal_mcp.tools.github_sync as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_fetch_github_events",
+        lambda u, t: [
+            _push_event("100"),
+            _issues_event("closed", "200"),
+            _watch_event("999"),
+        ],
+    )
+
+    result = github_sync(username="user", data_dir=str(data_dir))
+
+    assert result == {"saved": 2, "skipped": 1, "failed": 0}
+
+
+# ---------------------------------------------------------------------------
+# github_sync: API エラー応答・fetch 失敗の防御 (HIGH finding)
+# ---------------------------------------------------------------------------
+
+
+def test_github_sync_handles_non_list_api_response(data_dir: Path, monkeypatch) -> None:
+    """API が dict を返した場合（Bad credentials 等）にクラッシュしない。"""
+    import personal_mcp.tools.github_sync as mod
+
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: {"message": "Bad credentials"})
+
+    result = github_sync(username="user", data_dir=str(data_dir))
+
+    assert result == {"saved": 0, "skipped": 0, "failed": 1}
+    assert not (data_dir / "events.jsonl").exists()
+
+
+def test_github_sync_handles_fetch_exception(data_dir: Path, monkeypatch) -> None:
+    """_fetch_github_events が例外を投げた場合にクラッシュしない。"""
+    import personal_mcp.tools.github_sync as mod
+
+    def _raise(u, t):
+        raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(mod, "_fetch_github_events", _raise)
+
+    result = github_sync(username="user", data_dir=str(data_dir))
+
+    assert result == {"saved": 0, "skipped": 0, "failed": 1}
+
+
+# ---------------------------------------------------------------------------
+# CLI integration via server.main (--json output, token priority)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_github_sync_json_output(data_dir: Path, monkeypatch, capsys) -> None:
+    """--json flag outputs parseable JSON summary."""
+    import personal_mcp.tools.github_sync as mod
+    from personal_mcp.server import main
+
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+    main(["github-sync", "--username", "user", "--data-dir", str(data_dir), "--json"])
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    assert result["saved"] == 1
+    assert result["skipped"] == 0
+    assert result["failed"] == 0
+
+
+def test_cli_github_sync_text_output(data_dir: Path, monkeypatch, capsys) -> None:
+    """Text output shows saved/skipped/failed counts."""
+    import personal_mcp.tools.github_sync as mod
+    from personal_mcp.server import main
+
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+    main(["github-sync", "--username", "user", "--data-dir", str(data_dir)])
+
+    captured = capsys.readouterr()
+    assert "saved: 1" in captured.out
+    assert "skipped: 0" in captured.out
+    assert "failed: 0" in captured.out
+
+
+def test_cli_github_sync_env_token_used(data_dir: Path, monkeypatch) -> None:
+    """GITHUB_TOKEN env var is passed to fetch when --token is omitted."""
+    import personal_mcp.tools.github_sync as mod
+    from personal_mcp.server import main
+
+    captured_token: Dict[str, Any] = {}
+
+    def _capture(u, t):
+        captured_token["token"] = t
+        return []
+
+    monkeypatch.setattr(mod, "_fetch_github_events", _capture)
+    monkeypatch.setenv("GITHUB_TOKEN", "env-token-xyz")
+    main(["github-sync", "--username", "user", "--data-dir", str(data_dir)])
+
+    assert captured_token["token"] == "env-token-xyz"
+
+
+def test_cli_github_sync_explicit_token_overrides_env(data_dir: Path, monkeypatch) -> None:
+    """--token takes precedence over GITHUB_TOKEN env var."""
+    import personal_mcp.tools.github_sync as mod
+    from personal_mcp.server import main
+
+    captured_token: Dict[str, Any] = {}
+
+    def _capture(u, t):
+        captured_token["token"] = t
+        return []
+
+    monkeypatch.setattr(mod, "_fetch_github_events", _capture)
+    monkeypatch.setenv("GITHUB_TOKEN", "env-token")
+    main(["github-sync", "--username", "user", "--token", "tok", "--data-dir", str(data_dir)])
+
+    assert captured_token["token"] == "tok"


### PR DESCRIPTION
## Summary
- add github-sync CLI command to fetch GitHub user events manually
- map GitHub events into Event Contract v1 records and append to events.jsonl
- deduplicate by data.github_event_id and report saved/skipped/failed
- handle fetch/API-shape failures without crashing
- add unit tests for mapping, deduplication, error handling, and CLI integration

## Validation
- ruff check .
- ruff format --check .
- pytest -q

Closes #147