### PR TITLE
docs: reset #151 to boundary phase and split follow-ups

### DIFF
--- a/docs/issue-151-boundary-phase.md
+++ b/docs/issue-151-boundary-phase.md
@@ -1,0 +1,36 @@
+# Issue #151 Boundary Phase Memo
+
+## Purpose
+
+Issue #151 は「境界定義フェーズ」に戻し、先行して入っていた越境差分を外す。
+このメモは、レビュー指摘に対する整理結果と follow-up 分割先を記録する。
+
+## Scope For #151
+
+- 境界定義（責務整理・許可境界の論点整理）
+- follow-up Issue への分割と追跡
+
+## Out Of Scope For #151
+
+- policy/runbook/skills/guide 本体の直接更新
+- adapter 配布物の同期反映
+- 実装運用への先行反映
+
+## Follow-up Issues
+
+- #154 docs: AI_ROLE_POLICY境界を導線文書へ同期する
+- #155 docs/skills: codex-claude-bridgeをvNext境界へ全面同期する
+- #156 docs/skills: implement-onlyの実行モード定義を一意化する
+- #157 docs/runbook/policy: 境界変更反映の実施順を定義する
+
+## Execution Order
+
+1. #154 正本と導線の矛盾解消
+2. #155 codex-claude-bridge の vNext 同期
+3. #156 implement-only のモード一意化
+4. #157 境界変更反映の順序定義
+
+## Notes
+
+- この PR では越境差分を外し、Issue 契約（Out / Non-goals）との整合を優先する。
+- 実編集は follow-up Issue で段階的に行う。


### PR DESCRIPTION
## Summary
- #151 のレビュー指摘（Scope Guard / Non-goals 超過）に合わせ、越境していた docs 直接更新を差分から外しました。
- #151 は「境界定義フェーズ」に戻し、実編集は follow-up Issue に分割しました。

## Why This PR Shrinks The Diff
- 問題は変更方向ではなく、#151 の契約（Out / Non-goals）より先に policy/runbook/skills/guide 本体更新を混在させた点でした。
- そのため、差分を活かすより契約整合を優先して越境差分を除去しました。

## This PR Does
- `docs/issue-151-boundary-phase.md` を追加し、#151 の境界整理結果を記録
- follow-up Issue（#154 #155 #156 #157）を明示
- 実施順（導線同期 -> bridge同期 -> implement-only整列 -> 反映順定義）を記録

## This PR Does Not Do
- `docs/AI_ROLE_POLICY.md` の直接改訂
- `docs/CODEX_RUNBOOK.md` / `docs/skills/*` / `AI_GUIDE.md` / `CLAUDE.md` の直接改訂
- adapter 配布物同期や運用反映の実施

## Follow-up Issues
- #154 docs: AI_ROLE_POLICY境界を導線文書へ同期する
- #155 docs/skills: codex-claude-bridgeをvNext境界へ全面同期する
- #156 docs/skills: implement-onlyの実行モード定義を一意化する
- #157 docs/runbook/policy: 境界変更反映の実施順を定義する

## Review Alignment
- 既存レビューの主旨（弁明ではなく整理）に沿って、越境差分除去と分割起票を実施しました。

Refs #151
