### PR TITLE
docs: sync AI role policy routing docs

### DIFF
--- a/AI_GUIDE.md
+++ b/AI_GUIDE.md
@@ -116,7 +116,9 @@
 ## AI役割分離ポリシー
 
 - Claude は副作用を出さない実装担当、Codex は副作用を出す執行・検証担当です
-- 正本は [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) を参照してください
+- 正本は [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) です（この節と `CLAUDE.md` は導線です）
+- この節・`CLAUDE.md`・運用メモの記述が正本と矛盾する場合、正本を優先し、副作用を伴う作業は一旦停止して人間 Maintainer にエスカレーションしてください
+- 旧ルール参照による誤停止を避けるため、判断基準は常に正本に固定してください
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,15 @@ When starting any task, read files in this order before writing or changing anyt
 ## AI role split
 
 Claude remains the no-side-effect implementation side, and Codex remains the side-effecting executor/verifier.
-Authoritative policy: [`docs/AI_ROLE_POLICY.md`](./docs/AI_ROLE_POLICY.md)
+Authoritative policy: [`docs/AI_ROLE_POLICY.md`](./docs/AI_ROLE_POLICY.md) (this section is a routing summary, not the source of truth).
+
+If this file, `AI_GUIDE.md`, old templates, or historical comments conflict with the policy:
+
+1. prioritize `docs/AI_ROLE_POLICY.md`
+2. pause side-effecting work
+3. escalate to the human Maintainer with the conflicting citations
+
+To avoid false stops caused by stale wording, never treat non-authoritative role notes as a blocker by themselves.
 
 ## Practical guardrails for Claude Code
 

--- a/src/personal_mcp/AI_GUIDE.md
+++ b/src/personal_mcp/AI_GUIDE.md
@@ -116,7 +116,9 @@
 ## AI役割分離ポリシー
 
 - Claude は副作用を出さない実装担当、Codex は副作用を出す執行・検証担当です
-- 正本は [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) を参照してください
+- 正本は [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) です（この節と `CLAUDE.md` は導線です）
+- この節・`CLAUDE.md`・運用メモの記述が正本と矛盾する場合、正本を優先し、副作用を伴う作業は一旦停止して人間 Maintainer にエスカレーションしてください
+- 旧ルール参照による誤停止を避けるため、判断基準は常に正本に固定してください
 
 ---
 


### PR DESCRIPTION
## Summary
- update AI role split guidance in `AI_GUIDE.md` to explicitly treat `docs/AI_ROLE_POLICY.md` as the source of truth
- add conflict handling policy (pause side-effecting work and escalate to Maintainer) in `AI_GUIDE.md` and `CLAUDE.md`
- clarify stale-rule handling to reduce false stop risk from outdated role notes

## Validation
- `diff AI_GUIDE.md src/personal_mcp/AI_GUIDE.md`
- `pytest -q` (172 passed)

Closes #154
