### PR TITLE
docs: clarify vscode worker tasks as local-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ cython_debug/
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 .vscode/*.code-workspace
+.vscode/tasks.json
 
 # Ruff stuff:
 .ruff_cache/

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -90,6 +90,12 @@ ops     -> personal-mcp-core-ops
 - task 切替時は branch を切り替える前に対象 window/worktree を確認する
 - window 名に role を含める（例: `builder: personal-mcp-core-builder`）
 
+補足（ローカル運用）:
+
+- `human` 用ウィンドウ 1 つから、VSCode task で `advisor / builder / ops` 用 terminal を追加起動する運用は許容する
+- ただし、起動先ディレクトリや CLI コマンドはローカル依存が強いため、`.vscode/tasks.json` は repo で管理しない（各自ローカルで保持する）
+- repo には運用原則（worktree / branch / role 境界）のみを残し、task 定義の具体値は配布対象にしない
+
 ---
 
 ## 5. AI worker の責務境界
@@ -135,4 +141,3 @@ git fetch -p origin
 - 期待した worktree / branch で作業している
 - 意図しない差分がない
 - `main` 起点の新規 task branch を作成できる状態である
-


### PR DESCRIPTION
## 背景
- AI worker 用 terminal を VSCode task で起動する運用を試行中だが、現在の `.vscode/tasks.json` は `~/projects/pmc-*` などローカル依存が強い。
- 一方で repo 側には、運用思想（`worktree: 長期/役割ベース`、`branch: 短命/taskベース`）はすでに `docs/AI_WORKFLOW.md` に定義済み。

## 何を変えたか
- `.gitignore` に `.vscode/tasks.json` を追加し、ローカル task 定義の誤コミットを防止。
- `docs/AI_WORKFLOW.md` の VSCode 章に補足を追加。
  - 単一 human window から advisor/builder/ops terminal を task 追加起動する運用は許容
  - ただし task 定義の具体値はローカル依存のため repo 管理しない方針を明記

## なぜこの方針にしたか
- `.vscode/tasks.json` をそのまま配布設定として管理すると、起動先ディレクトリ/CLI コマンドが環境固有で壊れやすい。
- repo には再利用可能な原則（worktree/branch/role 境界）を残し、環境固有値はローカルに分離する方が責務分離が明確。

## ローカル依存や前提条件
- 各環境で必要な `.vscode/tasks.json` はローカルで保持・調整する（例: worktree パス、起動コマンド）。
- 本 PR は task 実体を変更/配布しない。

## レビュー観点
- `docs/AI_WORKFLOW.md` の補足が既存運用方針と矛盾していないか。
- `.gitignore` 追加が意図しない追跡漏れを生まないか（`tasks.json` のみ除外で十分か）。

## 確認
- `python3 -m json.tool .vscode/tasks.json`（JSON 構文 OK）
- dependency label の存在チェック（ローカル `tasks.json` 上で OK）
