### PR TITLE
feat(ui): simplify log input with optional labels

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -23,43 +23,93 @@ _HTML = """\
 <title>ログ入力</title>
 <style>
 body { font-family: system-ui; max-width: 480px; margin: 0 auto; padding: 1rem; }
+h2 { margin-bottom: 0.25rem; }
+p { margin-top: 0; color: #555; font-size: 0.9rem; }
 label { display: block; margin-top: 1rem; font-size: 0.9rem; color: #444; }
 select, textarea { width: 100%; padding: 0.5rem; font-size: 1rem; box-sizing: border-box; }
 textarea { height: 5rem; resize: vertical; }
-button { margin-top: 1.5rem; width: 100%; padding: 0.75rem; font-size: 1rem; cursor: pointer; }
+details { margin-top: 1rem; border-top: 1px solid #ddd; padding-top: 0.75rem; }
+summary { cursor: pointer; color: #333; font-size: 0.9rem; }
+button { margin-top: 1rem; width: 100%; padding: 0.75rem; font-size: 1rem; cursor: pointer; }
+#suggestion { margin-top: 0.5rem; color: #444; font-size: 0.9rem; }
 #msg { margin-top: 1rem; min-height: 1.5rem; }
 </style>
 </head>
 <body>
-<h2>ログ入力</h2>
+<h2>クイックログ</h2>
+<p>まずは気づきを記録。分類は後からでも大丈夫です。</p>
 <form id="f">
-  <label>テキスト<textarea id="text"></textarea></label>
-  <label>ドメイン *
-    <select id="domain" required>
-      <option value="">-- 選択 --</option>
-      DOMAIN_OPTIONS
-    </select>
-  </label>
-  <label>カインド *
-    <select id="kind" required>
-      <option value="">-- 選択 --</option>
-      KIND_OPTIONS
-    </select>
-  </label>
-  <label>アノテーション<textarea id="annotation"></textarea></label>
+  <label>気づき<textarea id="text" placeholder="いま起きたことを短く記録"></textarea></label>
+  <div id="suggestion"></div>
+  <details>
+    <summary>分類・補足を追加（任意）</summary>
+    <label>ドメイン
+      <select id="domain">
+        <option value="">(未指定) 候補を使う</option>
+        DOMAIN_OPTIONS
+      </select>
+    </label>
+    <label>カインド
+      <select id="kind">
+        <option value="">(未指定) 候補を使う</option>
+        KIND_OPTIONS
+      </select>
+    </label>
+    <label>アノテーション<textarea id="annotation"></textarea></label>
+  </details>
   <button type="submit">保存</button>
 </form>
 <div id="msg"></div>
 <script>
+function inferLabels(text) {
+  var t = (text || "").toLowerCase();
+  function hasAny(keywords) {
+    return keywords.some(function(k) {
+      return t.indexOf(k) >= 0;
+    });
+  }
+
+  var domain = "general";
+  if (hasAny(["poe", "map", "atlas", "ボス", "loot"])) {
+    domain = "poe2";
+  } else if (hasAny(["mood", "疲", "眠", "気分", "しんど"])) {
+    domain = "mood";
+  } else if (hasAny(["todo", "meeting", "進捗", "作業", "タスク"])) {
+    domain = "worklog";
+  } else if (hasAny(["issue", "pr", "実装", "設計", "docs", "コード"])) {
+    domain = "eng";
+  }
+
+  var kind = "note";
+  if (hasAny(["完了", "達成", "release", "マイルストーン"])) {
+    kind = "milestone";
+  } else if (hasAny(["作成", "更新", "artifact", "成果物"])) {
+    kind = "artifact";
+  } else if (hasAny(["調査", "検証", "対応", "実施", "session"])) {
+    kind = "session";
+  }
+  return { domain: domain, kind: kind };
+}
+
+function renderSuggestion() {
+  var text = document.getElementById("text").value;
+  var s = inferLabels(text);
+  document.getElementById("suggestion").textContent = "候補: " + s.domain + " / " + s.kind;
+}
+
+document.getElementById("text").addEventListener("input", renderSuggestion);
+renderSuggestion();
+
 document.getElementById("f").addEventListener("submit", async function(e) {
   e.preventDefault();
   var msg = document.getElementById("msg");
-  var body = {
-    text: document.getElementById("text").value,
-    domain: document.getElementById("domain").value,
-    kind: document.getElementById("kind").value,
-    annotation: document.getElementById("annotation").value
-  };
+  var body = { text: document.getElementById("text").value };
+  var domain = document.getElementById("domain").value;
+  var kind = document.getElementById("kind").value;
+  var annotation = document.getElementById("annotation").value;
+  if (domain) body.domain = domain;
+  if (kind) body.kind = kind;
+  if (annotation) body.annotation = annotation;
   try {
     var r = await fetch("/events", {
       method: "POST",
@@ -67,8 +117,10 @@ document.getElementById("f").addEventListener("submit", async function(e) {
       body: JSON.stringify(body)
     });
     if (r.ok) {
-      msg.textContent = "保存しました";
+      var saved = await r.json();
+      msg.textContent = "保存しました: " + saved.domain + " / " + saved.kind;
       document.getElementById("f").reset();
+      renderSuggestion();
     } else {
       var err = await r.json();
       msg.textContent = "エラー: " + (err.error || r.status);
@@ -220,16 +272,10 @@ def _make_handler(data_dir: str):
             text = (body.get("text") or "").strip()
             annotation = (body.get("annotation") or "").strip() or None
 
-            if not domain:
-                self._json(400, {"error": "domain is required"})
-                return
-            if not kind:
-                self._json(400, {"error": "kind is required"})
-                return
             try:
                 record = event_add_sqlite(
-                    domain=domain,
-                    kind=kind,
+                    domain=domain or None,
+                    kind=kind or None,
                     text=text,
                     annotation=annotation,
                     data_dir=data_dir or None,

--- a/src/personal_mcp/tools/log_form.py
+++ b/src/personal_mcp/tools/log_form.py
@@ -11,6 +11,33 @@ from personal_mcp.storage.sqlite import append_sqlite
 ALLOWED_KINDS: frozenset = frozenset(
     {"note", "session", "artifact", "milestone", "interaction", "maintenance"}
 )
+DEFAULT_DOMAIN = "general"
+DEFAULT_KIND = "note"
+
+
+def suggest_labels(text: str) -> Dict[str, str]:
+    """Suggest domain/kind labels from free text using lightweight heuristics."""
+    normalized = text.lower()
+
+    domain = DEFAULT_DOMAIN
+    if any(k in normalized for k in ("poe", "map", "atlas", "ボス", "loot")):
+        domain = "poe2"
+    elif any(k in normalized for k in ("mood", "疲", "眠", "気分", "しんど")):
+        domain = "mood"
+    elif any(k in normalized for k in ("todo", "meeting", "進捗", "作業", "タスク")):
+        domain = "worklog"
+    elif any(k in normalized for k in ("issue", "pr", "実装", "設計", "docs", "コード")):
+        domain = "eng"
+
+    kind = DEFAULT_KIND
+    if any(k in normalized for k in ("完了", "達成", "release", "マイルストーン")):
+        kind = "milestone"
+    elif any(k in normalized for k in ("作成", "更新", "artifact", "成果物")):
+        kind = "artifact"
+    elif any(k in normalized for k in ("調査", "検証", "対応", "実施", "session")):
+        kind = "session"
+
+    return {"domain": domain, "kind": kind}
 
 
 def _now_iso() -> str:
@@ -19,21 +46,25 @@ def _now_iso() -> str:
 
 def event_add_sqlite(
     *,
-    domain: str,
-    kind: str,
+    domain: Optional[str] = None,
+    kind: Optional[str] = None,
     text: str = "",
     annotation: Optional[str] = None,
     data_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build an Event Contract v1 record and append to SQLite.
 
-    domain and kind are required. text may be empty. annotation is stored in
-    data.annotation only when non-empty.
+    domain/kind are optional. If omitted, defaults or label suggestions are used.
+    text may be empty. annotation is stored in data.annotation only when non-empty.
     """
-    if domain not in ALLOWED_DOMAINS:
-        raise ValueError(f"unsupported domain: {domain}")
-    if kind not in ALLOWED_KINDS:
-        raise ValueError(f"unsupported kind: {kind}")
+    suggested = suggest_labels(text)
+    normalized_domain = (domain or "").strip() or suggested["domain"]
+    normalized_kind = (kind or "").strip() or suggested["kind"]
+
+    if normalized_domain not in ALLOWED_DOMAINS:
+        raise ValueError(f"unsupported domain: {normalized_domain}")
+    if normalized_kind not in ALLOWED_KINDS:
+        raise ValueError(f"unsupported kind: {normalized_kind}")
 
     extra: Dict[str, Any] = {}
     if annotation:
@@ -41,10 +72,10 @@ def event_add_sqlite(
 
     record = build_v1_record(
         ts=_now_iso(),
-        domain=domain,
+        domain=normalized_domain,
         text=text,
         tags=[],
-        kind=kind,
+        kind=normalized_kind,
         source="web-form",
         extra_data=extra or None,
     )

--- a/tests/test_log_form.py
+++ b/tests/test_log_form.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 import pytest
 
-from personal_mcp.tools.log_form import ALLOWED_KINDS, event_add_sqlite
+from personal_mcp.tools.log_form import (
+    ALLOWED_KINDS,
+    DEFAULT_DOMAIN,
+    DEFAULT_KIND,
+    event_add_sqlite,
+    suggest_labels,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -25,6 +31,18 @@ def test_event_add_sqlite_returns_v1_record(data_dir: Path) -> None:
     assert rec["data"]["text"] == "hello"
     assert rec["source"] == "web-form"
     assert "ts" in rec
+
+
+def test_event_add_sqlite_defaults_domain_kind_when_omitted(data_dir: Path) -> None:
+    rec = event_add_sqlite(text="hello", data_dir=str(data_dir))
+    assert rec["domain"] == DEFAULT_DOMAIN
+    assert rec["kind"] == DEFAULT_KIND
+
+
+def test_event_add_sqlite_uses_suggested_labels(data_dir: Path) -> None:
+    rec = event_add_sqlite(text="PR 実装を完了", data_dir=str(data_dir))
+    assert rec["domain"] == "eng"
+    assert rec["kind"] == "milestone"
 
 
 def test_event_add_sqlite_rejects_invalid_domain(data_dir: Path) -> None:
@@ -56,6 +74,11 @@ def test_event_add_sqlite_accepts_empty_text(data_dir: Path) -> None:
 def test_event_add_sqlite_accepts_all_allowed_kinds(data_dir: Path, kind: str) -> None:
     rec = event_add_sqlite(domain="general", kind=kind, data_dir=str(data_dir))
     assert rec["kind"] == kind
+
+
+def test_suggest_labels_defaults_to_general_note() -> None:
+    suggested = suggest_labels("just a memo")
+    assert suggested == {"domain": DEFAULT_DOMAIN, "kind": DEFAULT_KIND}
 
 
 # ---------------------------------------------------------------------------
@@ -146,20 +169,31 @@ def test_http_post_events_returns_201_on_valid_input(data_dir: Path) -> None:
     assert body["kind"] == "note"
 
 
-def test_http_post_events_400_missing_domain(data_dir: Path) -> None:
+def test_http_post_events_missing_domain_uses_default(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(handler_cls, {"kind": "note"}, str(data_dir))
+    responses = _post_events(handler_cls, {"kind": "note", "text": "hi"}, str(data_dir))
     status, body = responses[0]
-    assert status == 400
-    assert "domain" in body["error"]
+    assert status == 201
+    assert body["domain"] == "general"
+    assert body["kind"] == "note"
 
 
-def test_http_post_events_400_missing_kind(data_dir: Path) -> None:
+def test_http_post_events_missing_kind_uses_default(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(handler_cls, {"domain": "general"}, str(data_dir))
+    responses = _post_events(handler_cls, {"domain": "general", "text": "hi"}, str(data_dir))
     status, body = responses[0]
-    assert status == 400
-    assert "kind" in body["error"]
+    assert status == 201
+    assert body["domain"] == "general"
+    assert body["kind"] == "note"
+
+
+def test_http_post_events_missing_both_uses_suggestion(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    responses = _post_events(handler_cls, {"text": "PR 実装を完了"}, str(data_dir))
+    status, body = responses[0]
+    assert status == 201
+    assert body["domain"] == "eng"
+    assert body["kind"] == "milestone"
 
 
 def test_http_post_events_400_invalid_domain(data_dir: Path) -> None:
@@ -212,6 +246,15 @@ def test_http_post_empty_annotation_not_in_data(data_dir: Path) -> None:
     )
     _, body = responses[0]
     assert "annotation" not in body.get("data", {})
+
+
+def test_make_html_shows_optional_labels_and_suggestion() -> None:
+    from personal_mcp.adapters.http_server import _make_html
+
+    html = _make_html()
+    assert 'id="domain" required' not in html
+    assert 'id="kind" required' not in html
+    assert 'id="suggestion"' in html
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Allow minimal capture: /events accepts missing domain/kind and auto-fills from text suggestion
- Keep validation for explicit invalid labels
- Update web form to text-first flow with optional label section and live suggested labels
- Add tests for default/suggested labeling and optional form behavior

## Validation
- python3 -m ruff check src/personal_mcp/tools/log_form.py src/personal_mcp/adapters/http_server.py tests/test_log_form.py
- PYTHONPATH=src python3 -m pytest -q tests/test_log_form.py tests/test_daily_summary.py tests/test_heatmap_summary.py
- PYTHONPATH=src python3 -m pytest -q

Closes #169
