### PR TITLE
feat(workflow): Makefileで日常運用コマンド（run/log/today/summary/smoke）を最小整備する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-.PHONY: guide-sync guide-check issue-dag-list
+.PHONY: guide-sync guide-check issue-dag-list run log today summary smoke
 
 REPO ?= wakadorimk2/personal-mcp-core
 LIMIT ?= 200
 OUT ?= /tmp/issue-dag
 ISSUES_JSON ?= /tmp/issues.json
 WITH_TITLE ?=
+PYTHON ?= python
+DATA_DIR ?=
+PORT ?= 8080
+DATE ?= $(shell date -u +%F)
+TEXT ?=
+DOMAIN ?= worklog
+
+DATA_DIR_ARG = $(if $(strip $(DATA_DIR)),--data-dir "$(DATA_DIR)",)
 
 guide-sync:
 	cp AI_GUIDE.md src/personal_mcp/AI_GUIDE.md
@@ -15,3 +23,22 @@ guide-check:
 issue-dag-list:
 	gh issue list --repo "$(REPO)" --limit "$(LIMIT)" --json number,title,body > "$(ISSUES_JSON)"
 	python scripts/issue_dag.py "$(ISSUES_JSON)" --list $(if $(WITH_TITLE),--list-with-title,) --out "$(OUT)"
+
+run:
+	$(PYTHON) -m personal_mcp.server web-serve --port "$(PORT)" $(DATA_DIR_ARG)
+
+log:
+	@test -n "$(strip $(TEXT))" || (echo 'error: TEXT is required. usage: make log TEXT="..." [DOMAIN=worklog] [DATA_DIR=/path]'; exit 1)
+	$(PYTHON) -m personal_mcp.server event-add "$(TEXT)" --domain "$(DOMAIN)" $(DATA_DIR_ARG)
+
+today:
+	$(PYTHON) -m personal_mcp.server event-today $(DATA_DIR_ARG)
+
+summary:
+	$(PYTHON) -m personal_mcp.server summary-generate --date "$(DATE)" $(DATA_DIR_ARG)
+
+smoke:
+	@echo "smoke: DATA_DIR=$(if $(strip $(DATA_DIR)),$(DATA_DIR),(resolver default)) DATE=$(DATE)"
+	$(MAKE) log TEXT="smoke check $(DATE)" DOMAIN=worklog DATA_DIR="$(DATA_DIR)"
+	$(MAKE) today DATA_DIR="$(DATA_DIR)"
+	$(MAKE) summary DATE="$(DATE)" DATA_DIR="$(DATA_DIR)"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ python -m personal_mcp.server poe2-watch --client-log /path/to/Client.txt
 python -m personal_mcp.server event-list --date $(date +%Y-%m-%d)
 ```
 
+## Daily operation via Make
+
+日常運用の最小導線は `make` でも実行できる。
+
+```bash
+# 実運用データは repo 外に置く（例）
+export DATA_DIR="$HOME/.local/share/personal-mcp"
+
+# web UI 起動
+make run DATA_DIR="$DATA_DIR" PORT=8080
+
+# 最小ログ追加（TEXT は必須）
+make log DATA_DIR="$DATA_DIR" TEXT="朝会メモを記録"
+
+# 当日ログ確認
+make today DATA_DIR="$DATA_DIR"
+
+# 日次サマリー生成（UTC日付）
+make summary DATA_DIR="$DATA_DIR" DATE="$(date -u +%F)"
+
+# 上記導線の最小疎通確認
+make smoke DATA_DIR="$DATA_DIR" DATE="$(date -u +%F)"
+```
+
+`DATA_DIR` を渡さない場合は CLI の保存先解決（`--data-dir` > `PERSONAL_MCP_DATA_DIR` > XDG 既定）に従う。`repo/data/` は開発・テスト用であり、実運用の保存先には使わない。
+
+`make check` / `make test` / `make help` の拡張はこの Issue の対象外（follow-up 扱い）。
+
 ---
 
 ## Data storage


### PR DESCRIPTION
## Summary
- Add minimal daily-operation Make targets: `run`, `log`, `today`, `summary`, `smoke`
- Keep Make targets as thin wrappers around existing CLI commands (no CLI contract change)
- Add usage docs in README including `DATA_DIR` policy and follow-up boundary (`make check/test/help` out of scope)

## Changes
- `Makefile`
  - Add `.PHONY`: `run log today summary smoke`
  - Add minimal variables: `PYTHON`, `DATA_DIR`, `PORT`, `DATE`, `TEXT`, `DOMAIN`
  - Add `DATA_DIR_ARG` expansion for optional `--data-dir`
  - `make log` now fails fast when `TEXT` is empty
- `README.md`
  - Add "Daily operation via Make" section with concrete commands
  - Clarify `DATA_DIR` resolution and do-not-use `repo/data/` for production logs
  - Note follow-up scope for `make check/test/help`

## Validation
- `make log DATA_DIR="$(mktemp -d)" TEXT="issue177 verify"`
- `make today DATA_DIR="..."`
- `make summary DATA_DIR="..." DATE="$(date -u +%F)"`
- `make smoke DATA_DIR="..." DATE="$(date -u +%F)"`
- `make log DATA_DIR="..."` (without `TEXT`) -> fails as expected
- `timeout 2s make run DATA_DIR="$(mktemp -d)" PORT=18080` -> server start confirmed (terminated by timeout)

Closes #177
