### PR TITLE
feat(ui): add input mode switcher and UX telemetry events

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -11,7 +11,11 @@ from personal_mcp.tools.daily_summary import (
     get_latest_summary,
     list_summaries,
 )
-from personal_mcp.tools.log_form import ALLOWED_KINDS, event_add_sqlite
+from personal_mcp.tools.log_form import (
+    ALLOWED_KINDS,
+    event_add_sqlite,
+    ui_event_add_sqlite,
+)
 
 # DOMAIN_OPTIONS / KIND_OPTIONS are replaced at render time via str.replace()
 _HTML = """\
@@ -31,6 +35,30 @@ textarea { height: 5rem; resize: vertical; }
 details { margin-top: 1rem; border-top: 1px solid #ddd; padding-top: 0.75rem; }
 summary { cursor: pointer; color: #333; font-size: 0.9rem; }
 button { margin-top: 1rem; width: 100%; padding: 0.75rem; font-size: 1rem; cursor: pointer; }
+.mode-switcher { display: flex; gap: 0.5rem; margin-top: 1rem; }
+.mode-btn {
+  flex: 1;
+  margin-top: 0;
+  border: 1px solid #d0d0d0;
+  border-radius: 8px;
+  background: #f8f8f8;
+  color: #333;
+}
+.mode-btn.active { border-color: #ff7700; background: #fff3e6; color: #b14b00; font-weight: 600; }
+.mode-panel { display: none; margin-top: 0.75rem; }
+.mode-panel.active { display: block; }
+.chip-row { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.chip {
+  margin-top: 0;
+  width: auto;
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid #ddd;
+  background: #fff;
+  font-size: 0.9rem;
+}
+.chip.active { border-color: #ff7700; background: #fff3e6; color: #b14b00; }
+#tag-preview { margin-top: 0.5rem; color: #555; font-size: 0.85rem; min-height: 1.1rem; }
 #suggestion { margin-top: 0.5rem; color: #444; font-size: 0.9rem; }
 #msg { margin-top: 1rem; min-height: 1.5rem; }
 </style>
@@ -39,6 +67,33 @@ button { margin-top: 1rem; width: 100%; padding: 0.75rem; font-size: 1rem; curso
 <h2>クイックログ</h2>
 <p>まずは気づきを記録。分類は後からでも大丈夫です。</p>
 <form id="f">
+  <div class="mode-switcher" aria-label="入力モード切替">
+    <button type="button" class="mode-btn" data-mode="quick">quick</button>
+    <button type="button" class="mode-btn" data-mode="tag">tag</button>
+    <button type="button" class="mode-btn" data-mode="text">text</button>
+  </div>
+
+  <div id="panel-quick" class="mode-panel">
+    <div class="chip-row">
+      <button type="button" class="chip quick-chip" data-text="開始した">開始</button>
+      <button type="button" class="chip quick-chip" data-text="完了した">完了</button>
+      <button type="button" class="chip quick-chip" data-text="休憩する">休憩</button>
+    </div>
+  </div>
+
+  <div id="panel-tag" class="mode-panel">
+    <div class="chip-row">
+      <button type="button" class="chip tag-chip" data-tag="作業">作業</button>
+      <button type="button" class="chip tag-chip" data-tag="移動">移動</button>
+      <button type="button" class="chip tag-chip" data-tag="食事">食事</button>
+      <button type="button" class="chip tag-chip" data-tag="運動">運動</button>
+      <button type="button" class="chip tag-chip" data-tag="読書">読書</button>
+      <button type="button" class="chip tag-chip" data-tag="休憩">休憩</button>
+    </div>
+    <div id="tag-preview"></div>
+  </div>
+
+  <div id="panel-text" class="mode-panel"></div>
   <label>気づき<textarea id="text" placeholder="いま起きたことを短く記録"></textarea></label>
   <div id="suggestion"></div>
   <details>
@@ -61,6 +116,12 @@ button { margin-top: 1rem; width: 100%; padding: 0.75rem; font-size: 1rem; curso
 </form>
 <div id="msg"></div>
 <script>
+var UI_MODE_KEY = "daily_log_ui_mode";
+var VALID_UI_MODES = ["quick", "tag", "text"];
+var currentMode = "quick";
+var selectedTags = [];
+var inputStarted = false;
+
 function inferLabels(text) {
   var t = (text || "").toLowerCase();
   function hasAny(keywords) {
@@ -97,11 +158,88 @@ function renderSuggestion() {
   document.getElementById("suggestion").textContent = "候補: " + s.domain + " / " + s.kind;
 }
 
-document.getElementById("text").addEventListener("input", renderSuggestion);
-renderSuggestion();
+function isValidMode(mode) {
+  return VALID_UI_MODES.indexOf(mode) >= 0;
+}
 
-document.getElementById("f").addEventListener("submit", async function(e) {
-  e.preventDefault();
+function persistMode(mode) {
+  try { localStorage.setItem(UI_MODE_KEY, mode); } catch (e) {}
+}
+
+function readPersistedMode() {
+  try {
+    var mode = localStorage.getItem(UI_MODE_KEY);
+    return isValidMode(mode) ? mode : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+async function postUiEvent(eventName, extraData) {
+  var payload = {
+    event_name: eventName,
+    ui_mode: currentMode
+  };
+  if (extraData && typeof extraData === "object") {
+    payload.extra_data = extraData;
+  }
+  try {
+    await fetch("/events/ui", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify(payload)
+    });
+  } catch (e) {}
+}
+
+function setMode(mode, emitChange) {
+  if (!isValidMode(mode)) return;
+  var prev = currentMode;
+  currentMode = mode;
+  persistMode(mode);
+
+  document.querySelectorAll(".mode-btn").forEach(function(btn) {
+    var active = btn.dataset.mode === mode;
+    btn.classList.toggle("active", active);
+  });
+  document.querySelectorAll(".mode-panel").forEach(function(panel) {
+    panel.classList.toggle("active", panel.id === "panel-" + mode);
+  });
+
+  if (emitChange && prev !== mode) {
+    postUiEvent("ui_mode_changed", { from_mode: prev, to_mode: mode });
+  }
+}
+
+function markInputStarted() {
+  if (inputStarted) return;
+  inputStarted = true;
+  postUiEvent("input_started", {
+    text_length: document.getElementById("text").value.length,
+    selected_tag_count: selectedTags.length
+  });
+}
+
+function updateTagPreview() {
+  var preview = document.getElementById("tag-preview");
+  if (selectedTags.length === 0) {
+    preview.textContent = "タグ未選択";
+    return;
+  }
+  preview.textContent = "選択中: " + selectedTags.join(" / ");
+  document.getElementById("text").value = selectedTags.join(" ");
+  renderSuggestion();
+}
+
+function resetTagSelection() {
+  selectedTags = [];
+  document.querySelectorAll(".tag-chip").forEach(function(btn) {
+    btn.classList.remove("active");
+  });
+  updateTagPreview();
+}
+
+async function submitLog(trigger) {
   var msg = document.getElementById("msg");
   var body = { text: document.getElementById("text").value };
   var domain = document.getElementById("domain").value;
@@ -119,7 +257,16 @@ document.getElementById("f").addEventListener("submit", async function(e) {
     if (r.ok) {
       var saved = await r.json();
       msg.textContent = "保存しました: " + saved.domain + " / " + saved.kind;
+      await postUiEvent("input_submitted", {
+        trigger: trigger,
+        text_length: body.text.length,
+        resolved_domain: saved.domain,
+        resolved_kind: saved.kind,
+        selected_tag_count: selectedTags.length
+      });
       document.getElementById("f").reset();
+      resetTagSelection();
+      inputStarted = false;
       renderSuggestion();
     } else {
       var err = await r.json();
@@ -128,7 +275,54 @@ document.getElementById("f").addEventListener("submit", async function(e) {
   } catch(ex) {
     msg.textContent = "接続エラー: " + ex.message;
   }
+}
+
+document.querySelectorAll(".mode-btn").forEach(function(btn) {
+  btn.addEventListener("click", function() {
+    setMode(btn.dataset.mode, true);
+  });
 });
+
+document.querySelectorAll(".quick-chip").forEach(function(btn) {
+  btn.addEventListener("click", async function() {
+    markInputStarted();
+    document.getElementById("text").value = btn.dataset.text || "";
+    renderSuggestion();
+    await submitLog("quick_chip");
+  });
+});
+
+document.querySelectorAll(".tag-chip").forEach(function(btn) {
+  btn.addEventListener("click", function() {
+    markInputStarted();
+    var tag = btn.dataset.tag || "";
+    var idx = selectedTags.indexOf(tag);
+    if (idx >= 0) {
+      selectedTags.splice(idx, 1);
+      btn.classList.remove("active");
+    } else {
+      selectedTags.push(tag);
+      btn.classList.add("active");
+    }
+    updateTagPreview();
+  });
+});
+
+document.getElementById("text").addEventListener("focus", markInputStarted);
+document.getElementById("text").addEventListener("input", function() {
+  markInputStarted();
+  renderSuggestion();
+});
+
+document.getElementById("f").addEventListener("submit", async function(e) {
+  e.preventDefault();
+  markInputStarted();
+  await submitLog("form_submit");
+});
+
+setMode(readPersistedMode() || "quick", false);
+updateTagPreview();
+renderSuggestion();
 </script>
 </body>
 </html>"""
@@ -216,6 +410,16 @@ def _make_handler(data_dir: str):
             self.end_headers()
             self.wfile.write(payload)
 
+        def _read_json_body(self) -> Any:
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+            except ValueError as exc:
+                raise ValueError("invalid Content-Length") from exc
+            try:
+                return json.loads(self.rfile.read(length))
+            except Exception as exc:
+                raise ValueError("invalid JSON") from exc
+
         def do_GET(self) -> None:
             parsed = urlparse(self.path)
             if parsed.path in ("/", "/index.html"):
@@ -253,18 +457,36 @@ def _make_handler(data_dir: str):
                 self._json(404, {"error": "not found"})
 
         def do_POST(self) -> None:
-            if self.path != "/events":
+            if self.path not in ("/events", "/events/ui"):
                 self._json(404, {"error": "not found"})
                 return
             try:
-                length = int(self.headers.get("Content-Length", 0))
-            except ValueError:
-                self._json(400, {"error": "invalid Content-Length"})
+                body = self._read_json_body()
+            except ValueError as exc:
+                self._json(400, {"error": str(exc)})
                 return
-            try:
-                body = json.loads(self.rfile.read(length))
-            except Exception:
+            if not isinstance(body, dict):
                 self._json(400, {"error": "invalid JSON"})
+                return
+
+            if self.path == "/events/ui":
+                event_name = (body.get("event_name") or "").strip()
+                ui_mode = (body.get("ui_mode") or "").strip()
+                extra_data = body.get("extra_data")
+                if extra_data is not None and not isinstance(extra_data, dict):
+                    self._json(400, {"error": "extra_data must be an object"})
+                    return
+                try:
+                    record = ui_event_add_sqlite(
+                        event_name=event_name,
+                        ui_mode=ui_mode,
+                        data_dir=data_dir or None,
+                        extra_data=extra_data,
+                    )
+                except ValueError as exc:
+                    self._json(400, {"error": str(exc)})
+                    return
+                self._json(201, record)
                 return
 
             domain = (body.get("domain") or "").strip()

--- a/src/personal_mcp/tools/log_form.py
+++ b/src/personal_mcp/tools/log_form.py
@@ -11,6 +11,10 @@ from personal_mcp.storage.sqlite import append_sqlite
 ALLOWED_KINDS: frozenset = frozenset(
     {"note", "session", "artifact", "milestone", "interaction", "maintenance"}
 )
+ALLOWED_UI_MODES: frozenset = frozenset({"quick", "tag", "text"})
+ALLOWED_UI_EVENT_NAMES: frozenset = frozenset(
+    {"ui_mode_changed", "input_started", "input_submitted"}
+)
 DEFAULT_DOMAIN = "general"
 DEFAULT_KIND = "note"
 
@@ -78,6 +82,43 @@ def event_add_sqlite(
         kind=normalized_kind,
         source="web-form",
         extra_data=extra or None,
+    )
+    db_path = Path(resolve_data_dir(data_dir)) / "events.db"
+    append_sqlite(db_path, record)
+    return record
+
+
+def ui_event_add_sqlite(
+    *,
+    event_name: str,
+    ui_mode: str,
+    data_dir: Optional[str] = None,
+    extra_data: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Persist UI telemetry for UX experiments using Event Contract v1."""
+    normalized_event_name = (event_name or "").strip()
+    normalized_ui_mode = (ui_mode or "").strip()
+
+    if normalized_event_name not in ALLOWED_UI_EVENT_NAMES:
+        raise ValueError(f"unsupported ui event: {normalized_event_name}")
+    if normalized_ui_mode not in ALLOWED_UI_MODES:
+        raise ValueError(f"unsupported ui mode: {normalized_ui_mode}")
+
+    payload_data: Dict[str, Any] = {
+        "event_name": normalized_event_name,
+        "ui_mode": normalized_ui_mode,
+    }
+    if extra_data:
+        payload_data.update(extra_data)
+
+    record = build_v1_record(
+        ts=_now_iso(),
+        domain=DEFAULT_DOMAIN,
+        text=f"[ui] {normalized_event_name}",
+        tags=["ux", "experiment"],
+        kind="interaction",
+        source="web-form-ui",
+        extra_data=payload_data,
     )
     db_path = Path(resolve_data_dir(data_dir)) / "events.db"
     append_sqlite(db_path, record)

--- a/tests/test_log_form.py
+++ b/tests/test_log_form.py
@@ -6,10 +6,13 @@ import pytest
 
 from personal_mcp.tools.log_form import (
     ALLOWED_KINDS,
+    ALLOWED_UI_EVENT_NAMES,
+    ALLOWED_UI_MODES,
     DEFAULT_DOMAIN,
     DEFAULT_KIND,
     event_add_sqlite,
     suggest_labels,
+    ui_event_add_sqlite,
 )
 
 
@@ -81,6 +84,40 @@ def test_suggest_labels_defaults_to_general_note() -> None:
     assert suggested == {"domain": DEFAULT_DOMAIN, "kind": DEFAULT_KIND}
 
 
+def test_ui_event_add_sqlite_returns_v1_record(data_dir: Path) -> None:
+    rec = ui_event_add_sqlite(event_name="ui_mode_changed", ui_mode="quick", data_dir=str(data_dir))
+    assert rec["v"] == 1
+    assert rec["domain"] == "general"
+    assert rec["kind"] == "interaction"
+    assert rec["source"] == "web-form-ui"
+    assert rec["data"]["event_name"] == "ui_mode_changed"
+    assert rec["data"]["ui_mode"] == "quick"
+
+
+@pytest.mark.parametrize("event_name", sorted(ALLOWED_UI_EVENT_NAMES))
+def test_ui_event_add_sqlite_accepts_all_ui_event_names(data_dir: Path, event_name: str) -> None:
+    rec = ui_event_add_sqlite(event_name=event_name, ui_mode="tag", data_dir=str(data_dir))
+    assert rec["data"]["event_name"] == event_name
+
+
+@pytest.mark.parametrize("ui_mode", sorted(ALLOWED_UI_MODES))
+def test_ui_event_add_sqlite_accepts_all_ui_modes(data_dir: Path, ui_mode: str) -> None:
+    rec = ui_event_add_sqlite(event_name="input_started", ui_mode=ui_mode, data_dir=str(data_dir))
+    assert rec["data"]["ui_mode"] == ui_mode
+
+
+def test_ui_event_add_sqlite_rejects_invalid_event_name(data_dir: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported ui event"):
+        ui_event_add_sqlite(event_name="invalid_event", ui_mode="quick", data_dir=str(data_dir))
+
+
+def test_ui_event_add_sqlite_rejects_invalid_ui_mode(data_dir: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported ui mode"):
+        ui_event_add_sqlite(
+            event_name="input_submitted", ui_mode="keyboard", data_dir=str(data_dir)
+        )
+
+
 # ---------------------------------------------------------------------------
 # append_sqlite / DB content
 # ---------------------------------------------------------------------------
@@ -124,7 +161,7 @@ def test_db_is_outside_repo(monkeypatch, tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _post_events(handler_cls, body: dict, data_dir: str):
+def _post_json(handler_cls, body: dict, path: str):
     """Drive do_POST directly without a real socket via io.BytesIO."""
     import io
     from unittest.mock import MagicMock
@@ -137,7 +174,7 @@ def _post_events(handler_cls, body: dict, data_dir: str):
     handler.headers = {"Content-Length": str(len(raw)), "Content-Type": "application/json"}
     handler.rfile = io.BytesIO(raw)
     handler.wfile = io.BytesIO()
-    handler.path = "/events"
+    handler.path = path
     handler.request_version = "HTTP/1.1"
 
     responses = []
@@ -158,8 +195,8 @@ def _make_handler_for_test(data_dir: str):
 
 def test_http_post_events_returns_201_on_valid_input(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(
-        handler_cls, {"domain": "general", "kind": "note", "text": "hi"}, str(data_dir)
+    responses = _post_json(
+        handler_cls, {"domain": "general", "kind": "note", "text": "hi"}, "/events"
     )
     assert len(responses) == 1
     status, body = responses[0]
@@ -171,7 +208,7 @@ def test_http_post_events_returns_201_on_valid_input(data_dir: Path) -> None:
 
 def test_http_post_events_missing_domain_uses_default(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(handler_cls, {"kind": "note", "text": "hi"}, str(data_dir))
+    responses = _post_json(handler_cls, {"kind": "note", "text": "hi"}, "/events")
     status, body = responses[0]
     assert status == 201
     assert body["domain"] == "general"
@@ -180,7 +217,7 @@ def test_http_post_events_missing_domain_uses_default(data_dir: Path) -> None:
 
 def test_http_post_events_missing_kind_uses_default(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(handler_cls, {"domain": "general", "text": "hi"}, str(data_dir))
+    responses = _post_json(handler_cls, {"domain": "general", "text": "hi"}, "/events")
     status, body = responses[0]
     assert status == 201
     assert body["domain"] == "general"
@@ -189,7 +226,7 @@ def test_http_post_events_missing_kind_uses_default(data_dir: Path) -> None:
 
 def test_http_post_events_missing_both_uses_suggestion(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(handler_cls, {"text": "PR 実装を完了"}, str(data_dir))
+    responses = _post_json(handler_cls, {"text": "PR 実装を完了"}, "/events")
     status, body = responses[0]
     assert status == 201
     assert body["domain"] == "eng"
@@ -198,7 +235,7 @@ def test_http_post_events_missing_both_uses_suggestion(data_dir: Path) -> None:
 
 def test_http_post_events_400_invalid_domain(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(handler_cls, {"domain": "baddom", "kind": "note"}, str(data_dir))
+    responses = _post_json(handler_cls, {"domain": "baddom", "kind": "note"}, "/events")
     status, body = responses[0]
     assert status == 400
     assert "domain" in body["error"]
@@ -206,7 +243,7 @@ def test_http_post_events_400_invalid_domain(data_dir: Path) -> None:
 
 def test_http_post_events_400_invalid_kind(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(handler_cls, {"domain": "general", "kind": "badkind"}, str(data_dir))
+    responses = _post_json(handler_cls, {"domain": "general", "kind": "badkind"}, "/events")
     status, body = responses[0]
     assert status == 400
     assert "kind" in body["error"]
@@ -231,7 +268,7 @@ def test_http_post_events_400_invalid_content_length(data_dir: Path) -> None:
 
 def test_http_post_events_saves_to_db(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    _post_events(handler_cls, {"domain": "eng", "kind": "artifact", "text": "saved"}, str(data_dir))
+    _post_json(handler_cls, {"domain": "eng", "kind": "artifact", "text": "saved"}, "/events")
     db_path = data_dir / "events.db"
     assert db_path.exists()
     with sqlite3.connect(str(db_path)) as conn:
@@ -241,11 +278,55 @@ def test_http_post_events_saves_to_db(data_dir: Path) -> None:
 
 def test_http_post_empty_annotation_not_in_data(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
-    responses = _post_events(
-        handler_cls, {"domain": "general", "kind": "note", "annotation": ""}, str(data_dir)
+    responses = _post_json(
+        handler_cls, {"domain": "general", "kind": "note", "annotation": ""}, "/events"
     )
     _, body = responses[0]
     assert "annotation" not in body.get("data", {})
+
+
+def test_http_post_ui_events_returns_201_on_valid_input(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    responses = _post_json(
+        handler_cls,
+        {
+            "event_name": "ui_mode_changed",
+            "ui_mode": "quick",
+            "extra_data": {"from_mode": "text", "to_mode": "quick"},
+        },
+        "/events/ui",
+    )
+    assert len(responses) == 1
+    status, body = responses[0]
+    assert status == 201
+    assert body["kind"] == "interaction"
+    assert body["data"]["event_name"] == "ui_mode_changed"
+    assert body["data"]["ui_mode"] == "quick"
+    assert body["data"]["from_mode"] == "text"
+
+
+def test_http_post_ui_events_400_invalid_ui_mode(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    responses = _post_json(
+        handler_cls,
+        {"event_name": "input_started", "ui_mode": "keyboard"},
+        "/events/ui",
+    )
+    status, body = responses[0]
+    assert status == 400
+    assert "ui mode" in body["error"]
+
+
+def test_http_post_ui_events_400_non_object_extra_data(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    responses = _post_json(
+        handler_cls,
+        {"event_name": "input_started", "ui_mode": "tag", "extra_data": "bad"},
+        "/events/ui",
+    )
+    status, body = responses[0]
+    assert status == 400
+    assert "extra_data" in body["error"]
 
 
 def test_make_html_shows_optional_labels_and_suggestion() -> None:
@@ -255,6 +336,9 @@ def test_make_html_shows_optional_labels_and_suggestion() -> None:
     assert 'id="domain" required' not in html
     assert 'id="kind" required' not in html
     assert 'id="suggestion"' in html
+    assert 'data-mode="quick"' in html
+    assert 'data-mode="tag"' in html
+    assert 'data-mode="text"' in html
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add mobile-friendly UI mode switcher (`quick` / `tag` / `text`) to the daily log form
- persist selected UI mode in local storage for frictionless switching without opening settings
- add minimal UX telemetry pipeline via `POST /events/ui` and persist events to SQLite
- log required events for experiments: `ui_mode_changed`, `input_started`, `input_submitted`
- keep existing event schema and `/events` behavior unchanged

## Changes
- `src/personal_mcp/tools/log_form.py`
  - add `ui_event_add_sqlite(...)`
  - add mode/event allowlists and validation
- `src/personal_mcp/adapters/http_server.py`
  - add mode switcher UI + quick/tag/text interaction behavior
  - add localStorage mode persistence
  - add `POST /events/ui` endpoint for telemetry
- `tests/test_log_form.py`
  - add tests for UI telemetry writer and `/events/ui` handler
  - extend HTML assertions for mode switch UI

## Verification
- `PYTHONPATH=src ruff check src/personal_mcp/tools/log_form.py src/personal_mcp/adapters/http_server.py tests/test_log_form.py`
- `PYTHONPATH=src pytest -q tests/test_log_form.py`
- `PYTHONPATH=src pytest -q tests/test_heatmap_summary.py`

Closes #181
