### PR TITLE
feat(api): add /api/candidates with MVP merge rules

### DIFF
--- a/docs/candidate-api-v1.md
+++ b/docs/candidate-api-v1.md
@@ -1,0 +1,46 @@
+# candidate API v1
+
+Issue #186 の最小実装に対応する `GET /api/candidates` 契約。
+daily input UX MVP 方針（`docs/daily-input-ux-mvp.md`）の候補生成ルールを HTTP API として固定する。
+
+## Endpoint
+
+- `GET /api/candidates`
+
+## Response
+
+200 で候補配列を返す。最大 8 件。
+
+```json
+[
+  { "text": "休憩", "source": "recent" },
+  { "text": "作業開始", "source": "fixed" }
+]
+```
+
+### Fields
+
+- `text`: UI に表示する候補テキスト
+- `source`: 候補ソース（`recent` / `today_frequent` / `7d_frequent` / `fixed`）
+
+## Candidate rules
+
+- cold start 判定は API 側で実施する
+  - 対象イベント件数 `< 7`: `fixed` のみ返す
+  - 対象イベント件数 `>= 7`: 4ソースを有効化
+- マージ優先順: `recent > today_frequent > 7d_frequent > fixed`
+- 正規化後テキスト重複は 1 件に統合し、より高優先度ソースを採用する
+  - 正規化は `strip + lower`（前後空白除去 + 小文字化）
+- 最終表示件数は常に最大 8 件
+
+## Source extraction
+
+- `recent`: 直近 10 件のイベント `data.text`（新しい順）
+- `today_frequent`: 当日イベント `data.text` の頻度順
+- `7d_frequent`: 過去 7 日（当日含む）のイベント `data.text` の頻度順
+- `fixed`: API 内定義の固定候補
+
+## Notes
+
+- 候補対象は `domain != summary` かつ `kind != interaction` のイベントに限定する。
+- 本仕様は MVP 期間の v1 とし、閾値や固定候補語彙は follow-up Issue で調整する。

--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from personal_mcp.core.event import ALLOWED_DOMAINS
+from personal_mcp.tools.candidates import list_candidates
 from personal_mcp.tools.daily_summary import (
     count_events_by_date,
     get_latest_summary,
@@ -451,6 +452,8 @@ def _make_handler(data_dir: str):
                     self._json(200, rec)
             elif parsed.path == "/api/heatmap":
                 self._json(200, count_events_by_date(28, data_dir or None))
+            elif parsed.path == "/api/candidates":
+                self._json(200, list_candidates(data_dir or None))
             elif parsed.path == "/api/summaries/list":
                 self._json(200, list_summaries(28, data_dir or None))
             else:

--- a/src/personal_mcp/tools/candidates.py
+++ b/src/personal_mcp/tools/candidates.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from personal_mcp.storage.path import resolve_data_dir
+from personal_mcp.storage.sqlite import read_sqlite
+
+MAX_CANDIDATES = 8
+RECENT_SOURCE_LIMIT = 10
+COLD_START_THRESHOLD = 7
+FIXED_CANDIDATES: tuple[str, ...] = (
+    "作業開始",
+    "作業再開",
+    "休憩",
+    "食事",
+    "移動",
+    "作業完了",
+    "振り返り",
+    "就寝準備",
+)
+
+
+def _utc_date(ts_str: str) -> Optional[date]:
+    try:
+        ts = datetime.fromisoformat(ts_str)
+    except Exception:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc).date()
+
+
+def _normalize_text(text: str) -> str:
+    return text.strip().lower()
+
+
+def _is_candidate_event(row: Dict[str, Any]) -> bool:
+    if row.get("domain") == "summary":
+        return False
+    if row.get("kind") == "interaction":
+        return False
+    text = row.get("data", {}).get("text", "")
+    return isinstance(text, str) and bool(text.strip())
+
+
+def _event_text(row: Dict[str, Any]) -> str:
+    text = row.get("data", {}).get("text", "")
+    return text.strip() if isinstance(text, str) else ""
+
+
+def _recent_texts(rows: List[Dict[str, Any]]) -> List[str]:
+    recent = rows[-RECENT_SOURCE_LIMIT:]
+    return [_event_text(r) for r in reversed(recent)]
+
+
+def _frequent_texts(rows: List[Dict[str, Any]]) -> List[str]:
+    if not rows:
+        return []
+
+    counter: Counter[str] = Counter()
+    latest_idx: Dict[str, int] = {}
+    latest_text: Dict[str, str] = {}
+
+    for idx, row in enumerate(rows):
+        text = _event_text(row)
+        normalized = _normalize_text(text)
+        if not normalized:
+            continue
+        counter[normalized] += 1
+        latest_idx[normalized] = idx
+        latest_text[normalized] = text
+
+    ordered_keys = sorted(counter.keys(), key=lambda k: (-counter[k], -latest_idx[k], k))
+    return [latest_text[k] for k in ordered_keys]
+
+
+def _merge_sources(sources: List[tuple[str, List[str]]], limit: int) -> List[Dict[str, str]]:
+    merged: List[Dict[str, str]] = []
+    seen: set[str] = set()
+
+    for source_name, texts in sources:
+        for text in texts:
+            normalized = _normalize_text(text)
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            merged.append({"text": text.strip(), "source": source_name})
+            if len(merged) >= limit:
+                return merged
+    return merged
+
+
+def list_candidates(
+    data_dir: Optional[str] = None, limit: int = MAX_CANDIDATES
+) -> List[Dict[str, str]]:
+    if limit <= 0:
+        return []
+
+    db_path = Path(resolve_data_dir(data_dir)) / "events.db"
+    rows = [r for r in read_sqlite(db_path) if _is_candidate_event(r)]
+
+    fixed = list(FIXED_CANDIDATES)
+    if len(rows) < COLD_START_THRESHOLD:
+        return _merge_sources([("fixed", fixed)], limit=min(limit, MAX_CANDIDATES))
+
+    today = datetime.now(timezone.utc).date()
+    week_start = today - timedelta(days=6)
+
+    today_rows: List[Dict[str, Any]] = []
+    week_rows: List[Dict[str, Any]] = []
+    for row in rows:
+        row_date = _utc_date(str(row.get("ts", "")))
+        if row_date is None:
+            continue
+        if row_date == today:
+            today_rows.append(row)
+        if week_start <= row_date <= today:
+            week_rows.append(row)
+
+    sources = [
+        ("recent", _recent_texts(rows)),
+        ("today_frequent", _frequent_texts(today_rows)),
+        ("7d_frequent", _frequent_texts(week_rows)),
+        ("fixed", fixed),
+    ]
+    return _merge_sources(sources, limit=min(limit, MAX_CANDIDATES))

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import io
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from personal_mcp.core.event import build_v1_record
+from personal_mcp.storage.sqlite import append_sqlite
+from personal_mcp.tools.candidates import FIXED_CANDIDATES, list_candidates
+
+
+def _ts(days_ago: int, seq: int) -> str:
+    base = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return (base.replace(microsecond=0) + timedelta(seconds=seq)).isoformat()
+
+
+def _add_event(
+    db_path: Path,
+    *,
+    text: str,
+    days_ago: int = 0,
+    seq: int = 0,
+    domain: str = "general",
+    kind: str = "note",
+) -> None:
+    record = build_v1_record(
+        ts=_ts(days_ago, seq),
+        domain=domain,
+        text=text,
+        tags=[],
+        kind=kind,
+        source="test",
+    )
+    append_sqlite(db_path, record)
+
+
+def _norm(text: str) -> str:
+    return text.strip().lower()
+
+
+def _sources(items: List[Dict[str, str]]) -> List[str]:
+    return [x["source"] for x in items]
+
+
+def _make_handler_for_test(data_dir: str):
+    from personal_mcp.adapters.http_server import _make_handler
+
+    return _make_handler(data_dir)
+
+
+def _new_handler(handler_cls, path: str):
+    handler = handler_cls.__new__(handler_cls)
+    handler.headers = {}
+    handler.rfile = io.BytesIO(b"")
+    handler.wfile = io.BytesIO()
+    handler.path = path
+    handler.request_version = "HTTP/1.1"
+    return handler
+
+
+def _do_get_json(handler_cls, path: str) -> List[Tuple[int, Any]]:
+    handler = _new_handler(handler_cls, path)
+    responses: List[Tuple[int, Any]] = []
+    handler._json = lambda status, body: responses.append((status, body))
+    handler.do_GET()
+    return responses
+
+
+def test_list_candidates_cold_start_returns_fixed_only(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    for i in range(6):
+        _add_event(db_path, text=f"event-{i}", seq=i)
+
+    got = list_candidates(data_dir=str(data_dir))
+    expected = [{"text": t, "source": "fixed"} for t in FIXED_CANDIDATES]
+    assert got == expected
+
+
+@pytest.mark.parametrize("count", [7, 8])
+def test_list_candidates_threshold_7_and_8_enable_non_fixed_sources(
+    data_dir: Path, count: int
+) -> None:
+    db_path = data_dir / "events.db"
+    for i in range(count):
+        _add_event(db_path, text=f"log-{i}", seq=i)
+
+    got = list_candidates(data_dir=str(data_dir))
+    assert any(item["source"] != "fixed" for item in got)
+
+
+def test_list_candidates_dedup_prefers_higher_priority_source(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    texts = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "  休憩  "]
+    for i, text in enumerate(texts):
+        _add_event(db_path, text=text, seq=i)
+
+    got = list_candidates(data_dir=str(data_dir))
+    rest_items = [item for item in got if _norm(item["text"]) == "休憩"]
+    assert len(rest_items) == 1
+    assert rest_items[0]["source"] == "recent"
+
+
+def test_list_candidates_can_include_today_frequent_source(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    _add_event(db_path, text="today-only", seq=1)
+    _add_event(db_path, text="today-only", seq=2)
+    for i in range(3, 13):
+        _add_event(db_path, text="recent-repeat", seq=i)
+
+    got = list_candidates(data_dir=str(data_dir))
+    today_only = [item for item in got if item["text"] == "today-only"]
+    assert len(today_only) == 1
+    assert today_only[0]["source"] == "today_frequent"
+
+
+def test_list_candidates_can_include_7d_frequent_source(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    _add_event(db_path, text="week-only", days_ago=2, seq=1)
+    _add_event(db_path, text="week-only", days_ago=2, seq=2)
+    for i in range(3, 14):
+        _add_event(db_path, text="today-repeat", seq=i)
+
+    got = list_candidates(data_dir=str(data_dir))
+    week_only = [item for item in got if item["text"] == "week-only"]
+    assert len(week_only) == 1
+    assert week_only[0]["source"] == "7d_frequent"
+
+
+def test_list_candidates_caps_at_8(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    for i in range(20):
+        _add_event(db_path, text=f"event-{i:02d}", seq=i)
+
+    got = list_candidates(data_dir=str(data_dir))
+    assert len(got) == 8
+    assert _sources(got) == ["recent"] * 8
+
+
+def test_http_get_candidates_200(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    for i in range(8):
+        _add_event(db_path, text=f"event-{i}", seq=i)
+
+    handler_cls = _make_handler_for_test(str(data_dir))
+    responses = _do_get_json(handler_cls, "/api/candidates")
+    assert len(responses) == 1
+    status, body = responses[0]
+    assert status == 200
+    assert isinstance(body, list)
+    assert len(body) <= 8
+    assert all("text" in item and "source" in item for item in body)


### PR DESCRIPTION
## Summary
- add /api/candidates endpoint
- implement candidate merge logic (recent > today_frequent > 7d_frequent > fixed) with dedupe and max 8
- add cold start threshold handling (< 7 -> fixed only)
- document v1 contract in docs/candidate-api-v1.md
- add candidate-focused tests including 6/7/8 boundary and endpoint response

## Verification
- ruff check src/personal_mcp/tools/candidates.py src/personal_mcp/adapters/http_server.py tests/test_candidates.py
- PYTHONPATH=src pytest -q tests/test_candidates.py tests/test_heatmap_summary.py tests/test_log_form.py
- PYTHONPATH=src pytest -q

Closes #186