### PR TITLE
feat(storage): add db/jsonl migration tool commands

### DIFF
--- a/docs/infra/restore-mvp-draft.md
+++ b/docs/infra/restore-mvp-draft.md
@@ -108,7 +108,29 @@ wc -l <data-dir>/events.jsonl
 tail -n 5 <data-dir>/events.jsonl
 ```
 
-### 3. `event-list` で読み取れることを確認する
+### 3. 片方向欠損時は migration tool で再生成する
+
+`events.db` / `events.jsonl` どちらかが欠損した場合は、まず dry-run で件数差分を確認する。
+
+```sh
+# events.db -> events.jsonl 再生成（dry-run）
+personal-mcp storage-db-to-jsonl --dry-run --json --data-dir <data-dir>
+
+# events.jsonl -> events.db 再生成（dry-run）
+personal-mcp storage-jsonl-to-db --dry-run --json --data-dir <data-dir>
+```
+
+dry-run の結果が想定どおりであれば、実際に再生成する。
+
+```sh
+# events.db を正として events.jsonl を再生成
+personal-mcp storage-db-to-jsonl --data-dir <data-dir>
+
+# events.jsonl を元に events.db を再生成
+personal-mcp storage-jsonl-to-db --data-dir <data-dir>
+```
+
+### 4. `event-list` で読み取れることを確認する
 
 ```sh
 personal-mcp event-list --n 10 --data-dir <data-dir>

--- a/src/personal_mcp/server.py
+++ b/src/personal_mcp/server.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from personal_mcp.adapters.mcp_server import get_system_context
+from personal_mcp.storage.events_store import rebuild_db_from_jsonl, rebuild_jsonl_from_db
 from personal_mcp.storage.path import resolve_data_dir
 from personal_mcp.tools.event import event_add, event_list
 from personal_mcp.tools.daily_summary import generate_daily_summary
@@ -157,6 +158,20 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_summary.add_argument("--interpretation", default=None, help="optional interpretation text")
     p_summary.add_argument("--data-dir", default=None)
     p_summary.add_argument("--json", action="store_true")
+    p_db_to_jsonl = sub.add_parser(
+        "storage-db-to-jsonl",
+        help="regenerate events.jsonl from events.db",
+    )
+    p_db_to_jsonl.add_argument("--data-dir", default=None)
+    p_db_to_jsonl.add_argument("--dry-run", action="store_true")
+    p_db_to_jsonl.add_argument("--json", action="store_true")
+    p_jsonl_to_db = sub.add_parser(
+        "storage-jsonl-to-db",
+        help="regenerate events.db from events.jsonl",
+    )
+    p_jsonl_to_db.add_argument("--data-dir", default=None)
+    p_jsonl_to_db.add_argument("--dry-run", action="store_true")
+    p_jsonl_to_db.add_argument("--json", action="store_true")
 
     args = parser.parse_args(argv)
     data_dir = resolve_data_dir(getattr(args, "data_dir", None))
@@ -289,6 +304,44 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(json.dumps(record, ensure_ascii=False, indent=2))
         else:
             print(f"summary generated for {target_date}: {record['data']['text'][:60]}")
+        return 0
+
+    if args.cmd == "storage-db-to-jsonl":
+        try:
+            result = rebuild_jsonl_from_db(data_dir=data_dir, dry_run=args.dry_run)
+        except FileNotFoundError as exc:
+            print(f"error: {exc}", flush=True)
+            return 1
+
+        if args.json:
+            print(json.dumps(result, ensure_ascii=False))
+        else:
+            print(
+                "db->jsonl "
+                f"source={result['source_count']} "
+                f"target={result['target_count']} "
+                f"diff={result['count_diff']} "
+                f"dry_run={result['dry_run']}"
+            )
+        return 0
+
+    if args.cmd == "storage-jsonl-to-db":
+        try:
+            result = rebuild_db_from_jsonl(data_dir=data_dir, dry_run=args.dry_run)
+        except FileNotFoundError as exc:
+            print(f"error: {exc}", flush=True)
+            return 1
+
+        if args.json:
+            print(json.dumps(result, ensure_ascii=False))
+        else:
+            print(
+                "jsonl->db "
+                f"source={result['source_count']} "
+                f"target={result['target_count']} "
+                f"diff={result['count_diff']} "
+                f"dry_run={result['dry_run']}"
+            )
         return 0
 
     return 1

--- a/src/personal_mcp/storage/events_store.py
+++ b/src/personal_mcp/storage/events_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -30,3 +31,59 @@ def read_events(data_dir: Optional[str] = None) -> List[Dict[str, Any]]:
     if rows:
         return rows
     return read_jsonl(jsonl_path)
+
+
+def rebuild_jsonl_from_db(data_dir: Optional[str] = None, dry_run: bool = False) -> Dict[str, Any]:
+    """Regenerate compatibility JSONL from primary DB records."""
+    db_path, jsonl_path = _paths(data_dir)
+    if not db_path.exists():
+        raise FileNotFoundError(f"missing source file: {db_path}")
+
+    source_records = read_sqlite(db_path)
+    target_records = read_jsonl(jsonl_path)
+    result: Dict[str, Any] = {
+        "direction": "db_to_jsonl",
+        "dry_run": dry_run,
+        "source_path": str(db_path),
+        "target_path": str(jsonl_path),
+        "source_count": len(source_records),
+        "target_count": len(target_records),
+        "count_diff": len(source_records) - len(target_records),
+    }
+    if dry_run:
+        return result
+
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    with jsonl_path.open("w", encoding="utf-8") as f:
+        for record in source_records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    result["written_count"] = len(source_records)
+    return result
+
+
+def rebuild_db_from_jsonl(data_dir: Optional[str] = None, dry_run: bool = False) -> Dict[str, Any]:
+    """Regenerate primary DB from compatibility JSONL records."""
+    db_path, jsonl_path = _paths(data_dir)
+    if not jsonl_path.exists():
+        raise FileNotFoundError(f"missing source file: {jsonl_path}")
+
+    source_records = read_jsonl(jsonl_path)
+    target_records = read_sqlite(db_path)
+    result: Dict[str, Any] = {
+        "direction": "jsonl_to_db",
+        "dry_run": dry_run,
+        "source_path": str(jsonl_path),
+        "target_path": str(db_path),
+        "source_count": len(source_records),
+        "target_count": len(target_records),
+        "count_diff": len(source_records) - len(target_records),
+    }
+    if dry_run:
+        return result
+
+    if db_path.exists():
+        db_path.unlink()
+    for record in source_records:
+        append_sqlite(db_path, record)
+    result["written_count"] = len(source_records)
+    return result

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from personal_mcp.server import main
+from personal_mcp.storage.events_store import rebuild_db_from_jsonl, rebuild_jsonl_from_db
+from personal_mcp.storage.sqlite import append_sqlite, read_sqlite
+
+
+def _db_count(db_path: Path) -> int:
+    with sqlite3.connect(str(db_path)) as conn:
+        return int(conn.execute("SELECT COUNT(*) FROM events").fetchone()[0])
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(event, ensure_ascii=False) for event in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_rebuild_jsonl_from_db_dry_run_and_apply(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    jsonl_path = data_dir / "events.jsonl"
+    append_sqlite(
+        db_path,
+        {
+            "v": 1,
+            "ts": "2026-03-08T00:00:00+00:00",
+            "domain": "general",
+            "kind": "note",
+            "data": {"text": "from db 1"},
+            "tags": [],
+        },
+    )
+    append_sqlite(
+        db_path,
+        {
+            "v": 1,
+            "ts": "2026-03-08T01:00:00+00:00",
+            "domain": "eng",
+            "kind": "session",
+            "data": {"text": "from db 2"},
+            "tags": ["migration"],
+        },
+    )
+    _write_events(
+        jsonl_path,
+        [
+            {
+                "v": 1,
+                "ts": "2026-03-07T12:00:00+00:00",
+                "domain": "mood",
+                "kind": "note",
+                "data": {"text": "old jsonl"},
+                "tags": [],
+            }
+        ],
+    )
+
+    dry = rebuild_jsonl_from_db(data_dir=str(data_dir), dry_run=True)
+    assert dry["source_count"] == 2
+    assert dry["target_count"] == 1
+    assert dry["count_diff"] == 1
+    assert "written_count" not in dry
+    assert len(jsonl_path.read_text(encoding="utf-8").splitlines()) == 1
+
+    applied = rebuild_jsonl_from_db(data_dir=str(data_dir))
+    assert applied["written_count"] == 2
+    rows = [json.loads(line) for line in jsonl_path.read_text(encoding="utf-8").splitlines()]
+    assert [row["data"]["text"] for row in rows] == ["from db 1", "from db 2"]
+
+
+def test_rebuild_db_from_jsonl_dry_run_and_apply_with_legacy_normalization(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    jsonl_path = data_dir / "events.jsonl"
+    append_sqlite(
+        db_path,
+        {
+            "v": 1,
+            "ts": "2026-03-07T08:00:00+00:00",
+            "domain": "general",
+            "kind": "note",
+            "data": {"text": "to be replaced"},
+            "tags": [],
+        },
+    )
+    _write_events(
+        jsonl_path,
+        [
+            {
+                "ts": "2026-03-08T02:00:00+00:00",
+                "domain": "poe2",
+                "payload": {"text": "legacy entry"},
+                "tags": [],
+            },
+            {
+                "v": 1,
+                "ts": "2026-03-08T03:00:00+00:00",
+                "domain": "worklog",
+                "kind": "note",
+                "data": {"text": "v1 entry"},
+                "tags": [],
+            },
+        ],
+    )
+
+    dry = rebuild_db_from_jsonl(data_dir=str(data_dir), dry_run=True)
+    assert dry["source_count"] == 2
+    assert dry["target_count"] == 1
+    assert dry["count_diff"] == 1
+    assert _db_count(db_path) == 1
+
+    applied = rebuild_db_from_jsonl(data_dir=str(data_dir))
+    assert applied["written_count"] == 2
+    rows = read_sqlite(db_path)
+    assert len(rows) == 2
+    assert rows[0]["data"]["text"] == "legacy entry"
+    assert rows[1]["data"]["text"] == "v1 entry"
+
+
+def test_cli_storage_migration_dry_run_json_output(
+    data_dir: Path, capsys: pytest.CaptureFixture
+) -> None:
+    db_path = data_dir / "events.db"
+    jsonl_path = data_dir / "events.jsonl"
+    append_sqlite(
+        db_path,
+        {
+            "v": 1,
+            "ts": "2026-03-08T04:00:00+00:00",
+            "domain": "general",
+            "kind": "note",
+            "data": {"text": "db record"},
+            "tags": [],
+        },
+    )
+    _write_events(
+        jsonl_path,
+        [
+            {
+                "v": 1,
+                "ts": "2026-03-08T05:00:00+00:00",
+                "domain": "general",
+                "kind": "note",
+                "data": {"text": "jsonl record"},
+                "tags": [],
+            }
+        ],
+    )
+
+    rc_db_to_jsonl = main(
+        ["storage-db-to-jsonl", "--dry-run", "--json", "--data-dir", str(data_dir)]
+    )
+    report_db_to_jsonl = json.loads(capsys.readouterr().out)
+    assert rc_db_to_jsonl == 0
+    assert report_db_to_jsonl["direction"] == "db_to_jsonl"
+    assert report_db_to_jsonl["dry_run"] is True
+    assert report_db_to_jsonl["source_count"] == 1
+
+    rc_jsonl_to_db = main(
+        ["storage-jsonl-to-db", "--dry-run", "--json", "--data-dir", str(data_dir)]
+    )
+    report_jsonl_to_db = json.loads(capsys.readouterr().out)
+    assert rc_jsonl_to_db == 0
+    assert report_jsonl_to_db["direction"] == "jsonl_to_db"
+    assert report_jsonl_to_db["dry_run"] is True
+    assert report_jsonl_to_db["source_count"] == 1
+
+
+def test_cli_storage_db_to_jsonl_returns_error_when_source_missing(
+    data_dir: Path, capsys: pytest.CaptureFixture
+) -> None:
+    rc = main(["storage-db-to-jsonl", "--data-dir", str(data_dir)])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "missing source file" in captured.out


### PR DESCRIPTION
## Summary
- add bidirectional storage migration utilities between DB and JSONL with dry-run support
- add CLI commands for db->jsonl and jsonl->db migration execution
- add migration-focused tests and document restore procedure commands

## Validation
- All checks passed!
- .......                                                                  [100%]
7 passed in 0.14s

## Notes
- this PR is created from a clean recovery branch to avoid an unrelated merge history contamination

Closes #190