### PR TITLE
fix: ヒートマップの日付境界をローカル時間基準に修正

### DIFF
--- a/src/personal_mcp/tools/daily_summary.py
+++ b/src/personal_mcp/tools/daily_summary.py
@@ -21,6 +21,16 @@ def _utc_date(ts_str: str) -> Optional[str]:
         return None
 
 
+def _local_date(ts_str: str) -> Optional[str]:
+    try:
+        ts_dt = datetime.fromisoformat(ts_str)
+        if ts_dt.tzinfo is None:
+            ts_dt = ts_dt.replace(tzinfo=timezone.utc)
+        return ts_dt.astimezone().strftime("%Y-%m-%d")
+    except Exception:
+        return None
+
+
 def _parse_iso_date(date_str: str) -> Optional[date]:
     try:
         return datetime.strptime(date_str, "%Y-%m-%d").date()
@@ -69,11 +79,11 @@ def get_latest_summary(date: str, data_dir: Optional[str] = None) -> Optional[Di
 
 
 def count_events_by_date(days: int = 28, data_dir: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Return [{date, count}] for the last `days` UTC days, including 0-count days."""
+    """Return [{date, count}] for the last `days` local days, including 0-count days."""
     if days <= 0:
         return []
 
-    today = datetime.now(timezone.utc).date()
+    today = datetime.now().astimezone().date()
     buckets: Dict[str, int] = {}
     for i in range(days - 1, -1, -1):
         buckets[(today - timedelta(days=i)).isoformat()] = 0
@@ -81,7 +91,7 @@ def count_events_by_date(days: int = 28, data_dir: Optional[str] = None) -> List
     for r in read_events(data_dir=data_dir):
         if r.get("domain") == "summary":
             continue
-        d = _utc_date(r.get("ts", ""))
+        d = _local_date(r.get("ts", ""))
         if d and d in buckets:
             buckets[d] += 1
 

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -18,6 +18,10 @@ def _today_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
 
+def _today_local() -> str:
+    return datetime.now().astimezone().strftime("%Y-%m-%d")
+
+
 def _date_days_ago(days: int) -> str:
     return (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
 
@@ -96,7 +100,7 @@ def test_count_events_by_date_counts_today_events(data_dir: Path) -> None:
     _add_event(db_path, domain="mood")
     _add_event(db_path, domain="eng")
     result = count_events_by_date(28, data_dir=str(data_dir))
-    today_entry = next(r for r in result if r["date"] == _today_utc())
+    today_entry = next(r for r in result if r["date"] == _today_local())
     assert today_entry["count"] == 2
 
 
@@ -104,7 +108,7 @@ def test_count_events_by_date_excludes_summary_domain(data_dir: Path) -> None:
     db_path = data_dir / "events.db"
     _append_summary(db_path, _today_utc())
     result = count_events_by_date(28, data_dir=str(data_dir))
-    today_entry = next(r for r in result if r["date"] == _today_utc())
+    today_entry = next(r for r in result if r["date"] == _today_local())
     assert today_entry["count"] == 0
 
 


### PR DESCRIPTION
## 概要
オレンジの草ヒートマップが日を跨いでも次のマスに進まない問題を修正しました。

## 原因
`count_events_by_date` が UTC 日付でバケットを作成・集計していたため、ローカル日付の0時を跨いでも表示上は前日のままになることがありました。

## 変更内容
- `src/personal_mcp/tools/daily_summary.py`
  - ヒートマップ集計の日付境界を UTC からローカル時間へ変更
  - `_local_date` を追加し、イベントの所属日判定をローカル日付で実施
- `tests/test_heatmap_summary.py`
  - ヒートマップ集計テストの当日判定をローカル日付基準に更新

## 影響範囲
- ヒートマップ API（`/api/heatmap`）の日次集計のみ
- summary生成・保存（UTC前提）には変更なし

## テスト
- `PYTHONPATH=src pytest -q tests/test_heatmap_summary.py`
- `PYTHONPATH=src pytest -q tests/test_daily_summary.py`
