### PR TITLE
fix: compress dashboard candidates into short tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "personal-mcp-core"
 version = "0.1.0"
 requires-python = ">=3.10"
+dependencies = [
+    "fugashi[unidic-lite]>=1.5,<2",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/personal_mcp/tools/candidates.py
+++ b/src/personal_mcp/tools/candidates.py
@@ -9,11 +9,26 @@ from typing import Any, Dict, List, Optional
 from personal_mcp.storage.path import resolve_data_dir
 from personal_mcp.storage.sqlite import read_sqlite
 
+try:
+    from fugashi import Tagger
+except ImportError:  # pragma: no cover - exercised via fallback path in tests
+    Tagger = None
+
 MAX_CANDIDATES = 8
 RECENT_SOURCE_LIMIT = 10
 COLD_START_THRESHOLD = 7
 MAX_CANDIDATE_LENGTH = 10
 _SHORTEN_SPLIT = re.compile(r"[\s\u3000。、・：→←「」【】（）\[\]/|]+")
+_TRAILING_NOISE = re.compile(r"[~〜!！?？]+$")
+_ALNUM = re.compile(r"[A-Za-z0-9]")
+_ASCII_SLUG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_KATAKANA = re.compile(r"^[ァ-ヶー]+$")
+_HONORIFICS = frozenset({"さん", "ちゃん", "くん", "君", "氏", "様", "先生"})
+_CANDIDATE_STOPWORDS = frozenset(
+    {"今日", "明日", "昨日", "今", "朝", "昼", "夜", "夕方", "記録", "内容", "こと", "もの"}
+)
+_CANDIDATE_POS2 = frozenset({"普通名詞", "固有名詞"})
+_tagger: Optional[Any] = None
 FIXED_CANDIDATES: tuple[str, ...] = (
     "作業開始",
     "作業再開",
@@ -35,6 +50,119 @@ def _shorten_text(text: str) -> str:
     if parts:
         text = parts[0].strip()
     return text[:MAX_CANDIDATE_LENGTH]
+
+
+def _clean_candidate_text(text: str) -> str:
+    text = _TRAILING_NOISE.sub("", text.strip())
+    return text[:MAX_CANDIDATE_LENGTH]
+
+
+def _is_sensitive_label(text: str) -> bool:
+    return any(suffix in text for suffix in _HONORIFICS)
+
+
+def _is_meaningful_candidate(text: str) -> bool:
+    if not text:
+        return False
+    if text in _CANDIDATE_STOPWORDS:
+        return False
+    if len(text) == 1 and not (_ALNUM.search(text) or _KATAKANA.fullmatch(text)):
+        return False
+    return True
+
+
+def _feature_attr(word: Any, name: str) -> str:
+    feature = getattr(word, "feature", None)
+    value = getattr(feature, name, "")
+    if value in (None, "*"):
+        return ""
+    return str(value)
+
+
+def _get_tagger() -> Optional[Any]:
+    global _tagger
+    if Tagger is None:
+        return None
+    if _tagger is None:
+        try:
+            _tagger = Tagger()
+        except Exception:
+            _tagger = False
+    return _tagger or None
+
+
+def _tokenized_candidate(text: str) -> tuple[str, bool]:
+    tagger = _get_tagger()
+    if tagger is None:
+        return "", False
+
+    try:
+        words = list(tagger(text))
+    except Exception:
+        return "", False
+
+    chunks: List[str] = []
+    current: List[str] = []
+    sensitive_hit = False
+
+    for idx, word in enumerate(words):
+        surface = str(getattr(word, "surface", "")).strip()
+        if not surface:
+            continue
+
+        pos1 = _feature_attr(word, "pos1")
+        pos2 = _feature_attr(word, "pos2")
+        next_surface = ""
+        if idx + 1 < len(words):
+            next_surface = str(getattr(words[idx + 1], "surface", "")).strip()
+
+        if next_surface in _HONORIFICS and pos1 == "名詞":
+            sensitive_hit = True
+            if current:
+                chunks.append("".join(current))
+                current = []
+            continue
+
+        if pos1 == "名詞" and pos2 in _CANDIDATE_POS2 and surface not in _HONORIFICS:
+            current.append(surface)
+            continue
+
+        if current:
+            chunks.append("".join(current))
+            current = []
+
+    if current:
+        chunks.append("".join(current))
+
+    for chunk in chunks:
+        candidate = _clean_candidate_text(chunk)
+        if _is_sensitive_label(candidate):
+            sensitive_hit = True
+            continue
+        if _is_meaningful_candidate(candidate):
+            return candidate, sensitive_hit
+
+    if sensitive_hit:
+        return "", True
+    return "", False
+
+
+def _extract_candidate_text(text: str) -> str:
+    if _ASCII_SLUG.fullmatch(text.strip()):
+        return _clean_candidate_text(text)
+
+    tokenized, sensitive_hit = _tokenized_candidate(text)
+    if tokenized:
+        return tokenized
+    if sensitive_hit:
+        return ""
+
+    fallback = _clean_candidate_text(_shorten_text(text))
+    if _is_sensitive_label(fallback):
+        return ""
+    if _is_meaningful_candidate(fallback):
+        return fallback
+    return ""
 
 
 def _utc_date(ts_str: str) -> Optional[date]:
@@ -97,12 +225,12 @@ def _merge_sources(sources: List[tuple[str, List[str]]], limit: int) -> List[Dic
 
     for source_name, texts in sources:
         for text in texts:
-            shortened = _shorten_text(text)
-            normalized = _normalize_text(shortened)
+            candidate = _extract_candidate_text(text)
+            normalized = _normalize_text(candidate)
             if not normalized or normalized in seen:
                 continue
             seen.add(normalized)
-            merged.append({"text": shortened, "source": source_name})
+            merged.append({"text": candidate, "source": source_name})
             if len(merged) >= limit:
                 return merged
     return merged

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import io
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Tuple
 
 import pytest
 
+from personal_mcp.tools import candidates as candidates_mod
 from personal_mcp.core.event import build_v1_record
 from personal_mcp.storage.sqlite import append_sqlite
 from personal_mcp.tools.candidates import (
     FIXED_CANDIDATES,
     MAX_CANDIDATE_LENGTH,
+    _extract_candidate_text,
     _shorten_text,
     list_candidates,
 )
@@ -218,3 +221,109 @@ def test_list_candidates_long_events_produce_short_candidates(data_dir: Path) ->
     assert all(len(item["text"]) <= MAX_CANDIDATE_LENGTH for item in non_fixed), (
         f"all non-fixed candidates must be <= {MAX_CANDIDATE_LENGTH} chars: {non_fixed}"
     )
+
+
+class _FakeWord:
+    def __init__(self, surface: str, pos1: str, pos2: str = "") -> None:
+        self.surface = surface
+        self.feature = SimpleNamespace(pos1=pos1, pos2=pos2, lemma=surface)
+
+
+class _FakeTagger:
+    def __init__(self, mapping: Dict[str, List[_FakeWord]]) -> None:
+        self._mapping = mapping
+
+    def __call__(self, text: str) -> List[_FakeWord]:
+        return list(self._mapping[text])
+
+
+def test_extract_candidate_text_prefers_tokenized_noun_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mapping = {
+        "Codexを爆速で消費している": [
+            _FakeWord("Codex", "名詞", "普通名詞"),
+            _FakeWord("を", "助詞", "格助詞"),
+            _FakeWord("爆", "記号", "一般"),
+            _FakeWord("速", "名詞", "普通名詞"),
+            _FakeWord("で", "助詞", "格助詞"),
+            _FakeWord("消費", "名詞", "普通名詞"),
+        ],
+        "コードレビューを実施しました": [
+            _FakeWord("コード", "名詞", "普通名詞"),
+            _FakeWord("レビュー", "名詞", "普通名詞"),
+            _FakeWord("を", "助詞", "格助詞"),
+            _FakeWord("実施", "名詞", "普通名詞"),
+        ],
+    }
+    monkeypatch.setattr(candidates_mod, "_get_tagger", lambda: _FakeTagger(mapping))
+
+    assert _extract_candidate_text("Codexを爆速で消費している") == "Codex"
+    assert _extract_candidate_text("コードレビューを実施しました") == "コードレビュー"
+
+
+def test_extract_candidate_text_skips_name_with_honorific(monkeypatch: pytest.MonkeyPatch) -> None:
+    mapping = {
+        "久しぶりに沙耶ちゃんに会う": [
+            _FakeWord("久し", "形容詞", "一般"),
+            _FakeWord("沙耶", "名詞", "固有名詞"),
+            _FakeWord("ちゃん", "接尾辞", "名詞的"),
+            _FakeWord("会う", "動詞", "一般"),
+        ]
+    }
+    monkeypatch.setattr(candidates_mod, "_get_tagger", lambda: _FakeTagger(mapping))
+
+    assert _extract_candidate_text("久しぶりに沙耶ちゃんに会う") == ""
+
+
+def test_extract_candidate_text_fallback_skips_sensitive_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(candidates_mod, "_get_tagger", lambda: None)
+
+    assert _extract_candidate_text("沙耶ちゃん") == ""
+
+
+def test_list_candidates_filters_sensitive_name_when_tagger_available(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mapping = {
+        "久しぶりに沙耶ちゃんに会う": [
+            _FakeWord("久し", "形容詞", "一般"),
+            _FakeWord("沙耶", "名詞", "固有名詞"),
+            _FakeWord("ちゃん", "接尾辞", "名詞的"),
+            _FakeWord("会う", "動詞", "一般"),
+        ],
+        "Codexを爆速で消費している": [
+            _FakeWord("Codex", "名詞", "普通名詞"),
+            _FakeWord("を", "助詞", "格助詞"),
+            _FakeWord("消費", "名詞", "普通名詞"),
+        ],
+        "コードレビューを実施しました": [
+            _FakeWord("コード", "名詞", "普通名詞"),
+            _FakeWord("レビュー", "名詞", "普通名詞"),
+            _FakeWord("を", "助詞", "格助詞"),
+            _FakeWord("実施", "名詞", "普通名詞"),
+        ],
+    }
+    monkeypatch.setattr(candidates_mod, "_get_tagger", lambda: _FakeTagger(mapping))
+
+    db_path = data_dir / "events.db"
+    texts = [
+        "久しぶりに沙耶ちゃんに会う",
+        "Codexを爆速で消費している",
+        "コードレビューを実施しました",
+        "移動",
+        "休憩",
+        "振り返り",
+        "テストを書いていた",
+    ]
+    for i, text in enumerate(texts):
+        _add_event(db_path, text=text, seq=i)
+
+    got = list_candidates(data_dir=str(data_dir))
+    labels = [item["text"] for item in got]
+
+    assert "Codex" in labels
+    assert "コードレビュー" in labels
+    assert all("沙耶" not in label for label in labels)


### PR DESCRIPTION
## Summary
- shorten candidate labels before the max-length truncation so delimiter-separated logs collapse to the first tag-like token
- keep the existing candidates API shape while reducing sentence-like suggestions in the dashboard
- add focused tests for delimiter splitting and long-text candidate shortening

## Testing
- PYTHONPATH=src pytest -q tests/test_candidates.py
- PYTHONPATH=src pytest -q tests/test_heatmap_summary.py

Closes #214