### PR TITLE
feat(workflow): add Makefile dev setup targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: guide-sync guide-check issue-dag-list run log today summary smoke
+.PHONY: guide-sync guide-check issue-dag-list setup lint fmt format test run log today summary smoke
 
 REPO ?= wakadorimk2/personal-mcp-core
 LIMIT ?= 200
@@ -23,6 +23,20 @@ guide-check:
 issue-dag-list:
 	gh issue list --repo "$(REPO)" --limit "$(LIMIT)" --json number,title,body > "$(ISSUES_JSON)"
 	python scripts/issue_dag.py "$(ISSUES_JSON)" --list $(if $(WITH_TITLE),--list-with-title,) --out "$(OUT)"
+
+setup:
+	$(PYTHON) -m pip install -e ".[dev]"
+
+lint:
+	$(PYTHON) -m ruff check .
+
+fmt:
+	$(PYTHON) -m ruff format .
+
+format: fmt
+
+test:
+	$(PYTHON) -m pytest
 
 run:
 	$(PYTHON) -m personal_mcp.server web-serve --port "$(PORT)" $(DATA_DIR_ARG)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ make smoke DATA_DIR="$DATA_DIR" DATE="$(date -u +%F)"
 
 `DATA_DIR` を渡さない場合は CLI の保存先解決（`--data-dir` > `PERSONAL_MCP_DATA_DIR` > XDG 既定）に従う。`repo/data/` は開発・テスト用であり、実運用の保存先には使わない。
 
-`make check` / `make test` / `make help` の拡張はこの Issue の対象外（follow-up 扱い）。
+`make lint` / `make fmt` / `make test` は開発用導線として扱い、ここでは日常運用ターゲットだけを示している。`make check` / `make help` の拡張は引き続き follow-up 扱いとする。
 
 ---
 
@@ -145,21 +145,33 @@ make smoke DATA_DIR="$DATA_DIR" DATE="$(date -u +%F)"
 
 ## Development
 
+最短の開発開始手順:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+make setup
+make lint
+make test
+```
+
+`make setup` は `python -m pip install -e ".[dev]"` の薄いラッパーなので、optional dependency の `dev` を毎回思い出さなくてよい。
+
 ```bash
 # 開発用インストール
-pip install -e ".[dev]"
+make setup
 
 # コードチェック
-ruff check .
+make lint
 
 # 自動修正
 ruff check . --fix
 
 # フォーマット
-ruff format .
+make fmt
 
 # テスト
-pytest
+make test
 
 # AI_GUIDE.md の同期確認
 diff AI_GUIDE.md src/personal_mcp/AI_GUIDE.md


### PR DESCRIPTION
## Background

- `pyproject.toml` には `dev` optional dependency があるが、毎回 `.[dev]` を思い出す必要があった
- 既存の `Makefile` は日常運用向けターゲットが中心で、開発環境セットアップの入口がなかった
- #177 で追加した運用向けターゲットは維持しつつ、開発用導線だけを最小追加したい

## Changes

- `Makefile` に `setup` / `lint` / `fmt` / `format` / `test` を追加
- 開発ターゲットは既存の `PYTHON` 変数に合わせて `python -m ...` 形式に統一
- README に venv 作成から `make setup` / `make lint` / `make test` までの最短導線を追記
- 日常運用向けターゲットと開発向けターゲットの責務を README で分離して説明

## Added make targets

- `make setup`: `python -m pip install -e ".[dev]"`
- `make lint`: `python -m ruff check .`
- `make fmt`: `python -m ruff format .`
- `make format`: `make fmt` の alias
- `make test`: `python -m pytest`

## Verification

- `make -n setup lint fmt test`
- `make setup PYTHON=.venv/bin/python`
- `make lint PYTHON=.venv/bin/python`
- `make test PYTHON=.venv/bin/python`

## Remaining

- `make check` / `make help` は今回も対象外

Closes #227
