### PR TITLE
fix: handle client disconnects in http_server responses

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -528,13 +528,24 @@ def _make_handler(data_dir: str):
         def log_message(self, fmt: str, *args: Any) -> None:
             pass
 
+        def _write_response(
+            self, status: int, content_type: str, payload: bytes, *, charset: str | None = None
+        ) -> None:
+            try:
+                self.send_response(status)
+                header_value = content_type
+                if charset:
+                    header_value = f"{content_type}; charset={charset}"
+                self.send_header("Content-Type", header_value)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+            except (BrokenPipeError, ConnectionResetError):
+                return
+
         def _json(self, status: int, body: Any) -> None:
             payload = json.dumps(body, ensure_ascii=False).encode()
-            self.send_response(status)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(payload)))
-            self.end_headers()
-            self.wfile.write(payload)
+            self._write_response(status, "application/json", payload)
 
         def _read_json_body(self) -> Any:
             try:
@@ -550,18 +561,10 @@ def _make_handler(data_dir: str):
             parsed = urlparse(self.path)
             if parsed.path in ("/", "/index.html", "/dashboard"):
                 html = _DASHBOARD_HTML.encode("utf-8")
-                self.send_response(200)
-                self.send_header("Content-Type", "text/html; charset=utf-8")
-                self.send_header("Content-Length", str(len(html)))
-                self.end_headers()
-                self.wfile.write(html)
+                self._write_response(200, "text/html", html, charset="utf-8")
             elif parsed.path == "/input":
                 html = _make_html().encode("utf-8")
-                self.send_response(200)
-                self.send_header("Content-Type", "text/html; charset=utf-8")
-                self.send_header("Content-Length", str(len(html)))
-                self.end_headers()
-                self.wfile.write(html)
+                self._write_response(200, "text/html", html, charset="utf-8")
             elif parsed.path == "/health":
                 self._json(200, {"status": "ok"})
             elif parsed.path == "/summaries":

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -58,6 +58,7 @@ def _new_handler(handler_cls, path: str):
     handler.rfile = io.BytesIO(b"")
     handler.wfile = io.BytesIO()
     handler.path = path
+    handler.requestline = f"GET {path} HTTP/1.1"
     handler.request_version = "HTTP/1.1"
     return handler
 
@@ -79,6 +80,16 @@ def _do_get_html(handler_cls, path: str) -> Tuple[List[int], Dict[str, str], str
     handler.end_headers = lambda: None
     handler.do_GET()
     return statuses, headers, handler.wfile.getvalue().decode("utf-8")
+
+
+class _BrokenPipeWriter:
+    def write(self, _payload: bytes) -> int:
+        raise BrokenPipeError(32, "Broken pipe")
+
+
+class _ConnectionResetWriter:
+    def write(self, _payload: bytes) -> int:
+        raise ConnectionResetError(104, "Connection reset by peer")
 
 
 def test_count_events_by_date_returns_28_entries(data_dir: Path) -> None:
@@ -247,3 +258,17 @@ def test_http_get_dashboard_candidate_tap_script_exists(data_dir: Path) -> None:
     assert "tag.dataset.source = source;" in html
     assert "input.value = text;" in html
     assert 'await fetch("/api/candidates")' in html
+
+
+def test_http_get_dashboard_ignores_broken_pipe_from_client_disconnect(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    handler = _new_handler(handler_cls, "/dashboard")
+    handler.wfile = _BrokenPipeWriter()
+    handler.do_GET()
+
+
+def test_http_get_health_ignores_connection_reset_from_client_disconnect(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    handler = _new_handler(handler_cls, "/health")
+    handler.wfile = _ConnectionResetWriter()
+    handler.do_GET()


### PR DESCRIPTION
## Summary
- add a shared response writer in http_server for HTML and JSON responses
- swallow BrokenPipeError and ConnectionResetError when clients disconnect during response writes
- add regression tests for dashboard HTML and health JSON response paths

## Testing
- PYTHONPATH=src pytest tests/test_heatmap_summary.py tests/test_log_form.py -q

Closes #211