### PR TITLE
fix: improve candidate tokenization quality

### DIFF
--- a/src/personal_mcp/tools/candidates.py
+++ b/src/personal_mcp/tools/candidates.py
@@ -22,12 +22,13 @@ _SHORTEN_SPLIT = re.compile(r"[\s\u3000。、・：→←「」【】（）\[\]/
 _TRAILING_NOISE = re.compile(r"[~〜!！?？]+$")
 _ALNUM = re.compile(r"[A-Za-z0-9]")
 _ASCII_SLUG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_ASCII_WORD = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
 _KATAKANA = re.compile(r"^[ァ-ヶー]+$")
 _HONORIFICS = frozenset({"さん", "ちゃん", "くん", "君", "氏", "様", "先生"})
 _CANDIDATE_STOPWORDS = frozenset(
     {"今日", "明日", "昨日", "今", "朝", "昼", "夜", "夕方", "記録", "内容", "こと", "もの"}
 )
-_CANDIDATE_POS2 = frozenset({"普通名詞", "固有名詞"})
+_CANDIDATE_POS2 = frozenset({"普通名詞", "固有名詞", "数詞"})
 _tagger: Optional[Any] = None
 FIXED_CANDIDATES: tuple[str, ...] = (
     "作業開始",
@@ -66,6 +67,10 @@ def _is_meaningful_candidate(text: str) -> bool:
         return False
     if text in _CANDIDATE_STOPWORDS:
         return False
+    if text.isdigit():
+        return False
+    if _ASCII_SLUG.fullmatch(text) and len(text) <= 2 and text.islower():
+        return False
     if len(text) == 1 and not (_ALNUM.search(text) or _KATAKANA.fullmatch(text)):
         return False
     return True
@@ -91,6 +96,44 @@ def _get_tagger() -> Optional[Any]:
     return _tagger or None
 
 
+def _is_person_name(word: Any) -> bool:
+    return _feature_attr(word, "pos2") == "固有名詞" and _feature_attr(word, "pos3") == "人名"
+
+
+def _join_chunk_tokens(tokens: List[str]) -> str:
+    parts: List[str] = []
+    prev = ""
+    for token in tokens:
+        if parts and _ASCII_WORD.fullmatch(prev) and _ASCII_WORD.fullmatch(token):
+            parts.append(" ")
+        parts.append(token)
+        prev = token
+    return "".join(parts)
+
+
+def _candidate_from_chunk(tokens: List[str]) -> str:
+    if not tokens:
+        return ""
+
+    for size in range(len(tokens), 0, -1):
+        for start in range(len(tokens) - size + 1):
+            chunk = tokens[start : start + size]
+            variants = [_join_chunk_tokens(chunk), "".join(chunk)]
+            seen_variants: set[str] = set()
+            for variant in variants:
+                candidate = variant.strip()
+                if not candidate or candidate in seen_variants:
+                    continue
+                seen_variants.add(candidate)
+                if len(candidate) > MAX_CANDIDATE_LENGTH:
+                    continue
+                if _is_sensitive_label(candidate):
+                    continue
+                if _is_meaningful_candidate(candidate):
+                    return candidate
+    return ""
+
+
 def _tokenized_candidate(text: str) -> tuple[str, bool]:
     tagger = _get_tagger()
     if tagger is None:
@@ -101,7 +144,7 @@ def _tokenized_candidate(text: str) -> tuple[str, bool]:
     except Exception:
         return "", False
 
-    chunks: List[str] = []
+    chunks: List[List[str]] = []
     current: List[str] = []
     sensitive_hit = False
 
@@ -116,10 +159,17 @@ def _tokenized_candidate(text: str) -> tuple[str, bool]:
         if idx + 1 < len(words):
             next_surface = str(getattr(words[idx + 1], "surface", "")).strip()
 
+        if _is_person_name(word):
+            sensitive_hit = True
+            if current:
+                chunks.append(current)
+                current = []
+            continue
+
         if next_surface in _HONORIFICS and pos1 == "名詞":
             sensitive_hit = True
             if current:
-                chunks.append("".join(current))
+                chunks.append(current)
                 current = []
             continue
 
@@ -128,18 +178,15 @@ def _tokenized_candidate(text: str) -> tuple[str, bool]:
             continue
 
         if current:
-            chunks.append("".join(current))
+            chunks.append(current)
             current = []
 
     if current:
-        chunks.append("".join(current))
+        chunks.append(current)
 
     for chunk in chunks:
-        candidate = _clean_candidate_text(chunk)
-        if _is_sensitive_label(candidate):
-            sensitive_hit = True
-            continue
-        if _is_meaningful_candidate(candidate):
+        candidate = _candidate_from_chunk(chunk)
+        if candidate:
             return candidate, sensitive_hit
 
     if sensitive_hit:

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -237,6 +237,88 @@ class _FakeTagger:
         return list(self._mapping[text])
 
 
+def _legacy_feature_attr(word: Any, name: str) -> str:
+    feature = getattr(word, "feature", None)
+    value = getattr(feature, name, "")
+    if value in (None, "*"):
+        return ""
+    return str(value)
+
+
+def _legacy_tokenized_candidate(text: str) -> tuple[str, bool]:
+    tagger = candidates_mod._get_tagger()
+    if tagger is None:
+        return "", False
+
+    words = list(tagger(text))
+    chunks: List[str] = []
+    current: List[str] = []
+    sensitive_hit = False
+
+    for idx, word in enumerate(words):
+        surface = str(getattr(word, "surface", "")).strip()
+        if not surface:
+            continue
+
+        pos1 = _legacy_feature_attr(word, "pos1")
+        pos2 = _legacy_feature_attr(word, "pos2")
+        next_surface = ""
+        if idx + 1 < len(words):
+            next_surface = str(getattr(words[idx + 1], "surface", "")).strip()
+
+        if next_surface in candidates_mod._HONORIFICS and pos1 == "名詞":
+            sensitive_hit = True
+            if current:
+                chunks.append("".join(current))
+                current = []
+            continue
+
+        if (
+            pos1 == "名詞"
+            and pos2 in {"普通名詞", "固有名詞"}
+            and surface not in candidates_mod._HONORIFICS
+        ):
+            current.append(surface)
+            continue
+
+        if current:
+            chunks.append("".join(current))
+            current = []
+
+    if current:
+        chunks.append("".join(current))
+
+    for chunk in chunks:
+        candidate = candidates_mod._clean_candidate_text(chunk)
+        if candidates_mod._is_sensitive_label(candidate):
+            sensitive_hit = True
+            continue
+        if candidates_mod._is_meaningful_candidate(candidate):
+            return candidate, sensitive_hit
+
+    if sensitive_hit:
+        return "", True
+    return "", False
+
+
+def _legacy_extract_candidate_text(text: str) -> str:
+    if candidates_mod._ASCII_SLUG.fullmatch(text.strip()):
+        return candidates_mod._clean_candidate_text(text)
+
+    tokenized, sensitive_hit = _legacy_tokenized_candidate(text)
+    if tokenized:
+        return tokenized
+    if sensitive_hit:
+        return ""
+
+    fallback = candidates_mod._clean_candidate_text(candidates_mod._shorten_text(text))
+    if candidates_mod._is_sensitive_label(fallback):
+        return ""
+    if candidates_mod._is_meaningful_candidate(fallback):
+        return fallback
+    return ""
+
+
 def test_extract_candidate_text_prefers_tokenized_noun_chunk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -327,3 +409,47 @@ def test_list_candidates_filters_sensitive_name_when_tagger_available(
     assert "Codex" in labels
     assert "コードレビュー" in labels
     assert all("沙耶" not in label for label in labels)
+
+
+@pytest.mark.skipif(candidates_mod.Tagger is None, reason="fugashi not installed")
+@pytest.mark.parametrize(
+    ("text", "legacy", "current"),
+    [
+        ("Codexを爆速で消費している", "Codex", "Codex"),
+        ("コードレビューを実施しました", "コードレビュー", "コードレビュー"),
+        ("GitHub issue triageを進めた", "GitHubissu", "GitHub"),
+        ("VS Codeで調査した", "VSCode", "VS Code"),
+        ("山田さんと1on1した", "", "1on1"),
+        ("朝から開発環境を立ち上げ直した", "開発環境", "開発環境"),
+    ],
+)
+def test_extract_candidate_text_real_tagger_comparison_samples(
+    text: str, legacy: str, current: str
+) -> None:
+    assert _legacy_extract_candidate_text(text) == legacy
+    assert _extract_candidate_text(text) == current
+
+
+@pytest.mark.skipif(candidates_mod.Tagger is None, reason="fugashi not installed")
+def test_list_candidates_real_tagger_keeps_natural_candidates(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    texts = [
+        "GitHub issue triageを進めた",
+        "VS Codeで調査した",
+        "山田さんと1on1した",
+        "コードレビューを実施しました",
+        "Codexを爆速で消費している",
+        "朝から開発環境を立ち上げ直した",
+        "休憩",
+    ]
+    for i, text in enumerate(texts):
+        _add_event(db_path, text=text, seq=i)
+
+    got = list_candidates(data_dir=str(data_dir))
+    labels = [item["text"] for item in got]
+
+    assert "GitHub" in labels
+    assert "VS Code" in labels
+    assert "1on1" in labels
+    assert "コードレビュー" in labels
+    assert all("山田" not in label for label in labels)


### PR DESCRIPTION
## Summary
- improve tokenized candidate selection so mixed ASCII/Japanese phrases stay natural within the 10-char limit
- treat person-name tokens as sensitive while still allowing safe follow-up candidates such as 1on1
- add real fugashi comparison samples that pin old vs new extraction results for issue #234

## Testing
- PYTHONPATH=src python -m pytest -q tests/test_candidates.py
- python -m ruff check src/personal_mcp/tools/candidates.py tests/test_candidates.py

Closes #234