### PR TITLE
docs: cleanup pipeline の実行面と記録面を定義する

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ src/personal_mcp/
 | [`docs/domain-extension-policy.md`](./docs/domain-extension-policy.md) | domain 拡張条件 |
 | [`docs/architecture.md`](./docs/architecture.md) | 技術的アーキテクチャ |
 | [`docs/cleanup-architecture.md`](./docs/cleanup-architecture.md) | cleanup taxonomy / constitution / cleanup と仕様変更の境界 |
+| [`docs/cleanup-pipeline.md`](./docs/cleanup-pipeline.md) | cleanup の入力、実行面、auto-fix/report/triage、Issue/Project 記録フロー |
 | [`docs/import-layering-dependency-constraints.md`](./docs/import-layering-dependency-constraints.md) | import / layering / dependency 制約の設計 |
 | [`docs/deterministic-toolchain-baseline.md`](./docs/deterministic-toolchain-baseline.md) | deterministic guardrail の baseline と導入順序 |
 | [`docs/infra/notify-wrapper.md`](./docs/infra/notify-wrapper.md) | `notify` wrapper の使い方と通知チャネル追加契約 |

--- a/docs/cleanup-architecture.md
+++ b/docs/cleanup-architecture.md
@@ -2,10 +2,11 @@
 
 > スコープ: cleanup を単発作業ではなく、継続運用できる architecture として定義する
 > 親 Issue: #259
-> 関連: #94, #258, #260
-> 更新日: 2026-03-09
+> 関連: #94, #258, #260, #263, #264
+> 更新日: 2026-03-10
 >
 > **この文書は設計記録であり、cleanup pipeline や scheduler の実装導入は後続 Issue へ分離する。**
+> 実行面の設計は [`docs/cleanup-pipeline.md`](./cleanup-pipeline.md) を参照する。
 
 ---
 
@@ -236,9 +237,10 @@ cleanup は「雑にきれいにする作業」ではなく、
 drift を分類し、正本との距離を測り、
 auto-fix 境界と停止条件を固定したうえで扱う運用である。
 
-この文書で固定したのは次の 4 点である。
+この文書で固定したのは次の 5 点である。
 
 - cleanup taxonomy は `micro cleanup` / `periodic cleanup` / `doc drift detection`
 - 自動化は `L0-L3` の bounded model で扱う
 - auto-fix は「正本が明確で、非仕様変更で、局所 diff」の場合に限る
 - cleanup と spec change は「意味や約束を変えるか」で分ける
+- 実行面と記録面は [`docs/cleanup-pipeline.md`](./cleanup-pipeline.md) で別管理する

--- a/docs/cleanup-pipeline.md
+++ b/docs/cleanup-pipeline.md
@@ -1,0 +1,272 @@
+# Cleanup Pipeline — Execution Surfaces and Maintenance Loop
+
+> 種別: execution design / operating model
+> Issue: #264
+> 親 Issue: #259
+> 前提: #260, #261, #262, #263
+> 更新日: 2026-03-10
+>
+> **この文書は cleanup の実行面と記録面を定義する。CI / hook / scheduler の実装導入は後続 Issue へ分離する。**
+
+---
+
+## Goal
+
+`personal-mcp-core` における cleanup を、
+「どの signal を入力にするか」
+「どの実行面で何を流すか」
+「auto-fix / auto-report / manual triage をどこで分けるか」
+「Issue / Project にどう記録するか」
+の 4 点で repeatable maintenance loop にする。
+
+この文書では、`docs/cleanup-architecture.md` の taxonomy / constitution と、
+`docs/doc-drift-detection.md` の detector design を、
+実際の運用フローへ接続する。
+
+## Non-goal
+
+- Git hook、CI workflow、cron、scheduler の実装導入
+- detector や structural rule 自体の実装完了
+- 既存 backlog の一括 cleanup 実行
+- cleanup report をその場で自動的に merge / close する運用
+
+## 1. 前提として読む文書
+
+この pipeline は次の 4 文書を前提にする。
+
+| 先行 Issue | 文書 | この pipeline で使うもの |
+|---|---|---|
+| `#260` | [`docs/deterministic-toolchain-baseline.md`](./deterministic-toolchain-baseline.md) | local preflight / review 補助 / CI 候補の実行面 |
+| `#261` | [`docs/cleanup-architecture.md`](./cleanup-architecture.md) | cleanup taxonomy、automation level、constitution |
+| `#262` | [`docs/import-layering-dependency-constraints.md`](./import-layering-dependency-constraints.md) | structural drift の signal と hard fail / advisory 候補 |
+| `#263` | [`docs/doc-drift-detection.md`](./doc-drift-detection.md) | doc drift detector の signal、report 形式、triage ルール |
+
+要点:
+
+- `#261` が「cleanup とみなしてよい境界」を固定する
+- `#260` `#262` `#263` が pipeline に流し込む signal の供給源になる
+- 本文書はそれらを「いつ」「どこで」「何として処理するか」に落とす
+
+## 2. Pipeline Inputs
+
+cleanup pipeline が入力として扱う signal は次の 4 群に分ける。
+
+| input family | source | representative signal | primary consumer |
+|---|---|---|---|
+| task-local observation | 実作業中の diff、近傍 docs / tests、human review | typo、broken link、局所 drift、obsolete 補助記述 | micro cleanup |
+| deterministic baseline | `ruff`, `pytest`, `guide-check`, repo exploration tooling | command surface drift、導線不整合、review 前 mismatch | micro cleanup / report |
+| structural constraints | import / layering / dependency rule | hard fail 候補、advisory structural drift | report / manual triage |
+| doc drift detection | path existence, reference integrity, source-of-truth mismatch, orphan doc drift | stale docs、broken anchor、canonical conflict | report / periodic cleanup |
+
+補足:
+
+- signal の「意味判定」は `#261` の constitution に従う
+- detector が signal を返しても、直ちに cleanup 実行とはみなさない
+- pipeline は input を `micro cleanup` `periodic cleanup` `doc drift detection` のいずれかへ分類して流す
+
+## 3. Execution Surfaces
+
+cleanup を流す実行面は 4 つに固定する。
+
+| surface | timing | main input | allowed route | expected output | record destination |
+|---|---|---|---|---|---|
+| task-local loop | 実装 / docs 作業中、または optional local hook | task-local observation、軽量 deterministic check | auto-fix / auto-report | 小さい cleanup patch、または follow-up note 1 件 | 現在の PR、または新規/既存 Issue |
+| review preflight | PR 前 review / handoff 前 | deterministic baseline、advisory structural/doc signals | auto-report が基本。bounded auto-fix は別 patch へ委譲 | mismatch list、修正要否の報告 | PR コメント、PR 本文、follow-up Issue |
+| CI report | branch / PR 上の非破壊検査 | deterministic baseline、detector report | auto-report のみ | report artifact、failed check、advisory list | CI artifact、PR check summary、follow-up Issue |
+| weekly triage | 週次 20 分の棚卸し | CI report、preflight report、orphan inventory、未処理 backlog | manual triage | scope を絞った cleanup Issue / PR plan、dependency 更新 | Issue、Project metadata、運用コメント |
+
+設計意図:
+
+- 即時修正が可能なものは task-local loop へ寄せる
+- fix 不能だが観測価値が高いものは review preflight / CI report で止める
+- 広域の棚卸しと分割判断は weekly triage に集約する
+
+## 4. Micro Cleanup と Periodic Cleanup の違い
+
+| 観点 | micro cleanup | periodic cleanup |
+|---|---|---|
+| main trigger | 現在触っている diff の近傍で drift を見つけたとき | report 蓄積、週次棚卸し、repo inventory の見直し時 |
+| primary input | 現在の差分、近傍 file、正本 docs、既存テスト | CI/preflight report、orphan 候補、unused path、近接 Issue 群 |
+| expected output | 現在の task に同梱できる小さい patch、または follow-up Issue 1 件 | cleanup plan、親子に分割された Issue 群、別 PR に切った cleanup 実行 |
+| automation ceiling | `L2` まで | `L3` 前提 |
+| turnaround | 同一 task / 同一 PR で回収する | triage 後に別 task として着手する |
+| review need | 局所 diff なら短時間 review で足りる | inventory と分割方針の review が先に必要 |
+
+運用ルール:
+
+- micro cleanup は「今の文脈で source of truth が明確」なときだけ current task に同梱する
+- periodic cleanup は先に `inventory -> split -> prioritize` を行い、一括修正より分割を優先する
+
+## 5. Routing Rules
+
+pipeline は各 signal を次の 3 ルートへ振り分ける。
+
+### 5.1 Auto-fix
+
+条件:
+
+1. `#261` の auto-fix 条件をすべて満たす
+2. category が `micro cleanup`、または `doc drift detection` のうち truth が明確な局所同期である
+3. diff が現在の task か、その隣接 patch として閉じる
+
+典型例:
+
+- typo / broken link 修正
+- README や runbook を canonical doc に同期
+- 正本が明確な command surface drift の補正
+
+出力:
+
+- 現在の branch 上の小さい patch
+- 必要なら PR 本文に `trigger / source of truth / decision / scope / automation level / evidence` を明記
+
+### 5.2 Auto-report
+
+条件:
+
+- signal は deterministic に観測できる
+- ただし apply は unsafe、または scope が current task を超える
+
+典型例:
+
+- doc drift detector が返す mismatch list
+- advisory structural rule 違反候補
+- command surface drift のうち、docs と実装のどちらが truth か未確定なもの
+
+出力:
+
+- report artifact
+- PR comment / check summary
+- follow-up Issue draft の材料
+
+原則:
+
+- auto-report は「修正しない」のではなく、「triage 入力を lossless に残す」ためのルートとする
+- detector が `false positive` の可能性を含む場合も evidence は残す
+
+### 5.3 Manual triage
+
+条件:
+
+- category が `periodic cleanup`
+- canonical が未確定
+- structural / contract / responsibility change に波及する
+- diff が広く、inventory と分割なしでは監査不能
+
+典型例:
+
+- orphan doc 候補の棚卸し
+- docs / policy / runbook の責務重複の見直し
+- structural drift を hard fail に上げる前の例外整理
+
+出力:
+
+- scope を絞った cleanup parent Issue
+- child Issue への分割
+- `blocked-by` / `sub-issue` の dependency 整理
+
+## 6. End-to-End Flow
+
+cleanup pipeline の標準フローは次の順序に固定する。
+
+1. `detect`
+   - task-local observation、detector、baseline check から signal を得る
+2. `classify`
+   - `micro cleanup` / `periodic cleanup` / `doc drift detection`
+   - automation level (`L0-L3`)
+   - source of truth の明確さ
+3. `route`
+   - auto-fix / auto-report / manual triage のいずれかに振り分ける
+4. `execute`
+   - task-local patch、report 出力、または triage issue 化を行う
+5. `record`
+   - Issue / PR / Project に判断理由と残件を残す
+
+```text
+signal
+  -> classify(category, automation, truth)
+  -> route(auto-fix | auto-report | manual triage)
+  -> execute(surface-specific action)
+  -> record(issue/pr/project evidence)
+```
+
+重要:
+
+- route 前に fix しない
+- record を省略して「気づいた人の記憶」に戻さない
+- periodic cleanup は execute の前に split を挟んでよい
+
+## 7. Record Destinations
+
+cleanup の記録先は「何を実行したか」ではなく、
+「なぜその route にしたか」が読める形にそろえる。
+
+### 7.1 PR に残すもの
+
+現在の task に同梱した micro cleanup は、PR 説明またはレビューコメントに次を残す。
+
+- trigger
+- category
+- source of truth
+- decision
+- scope
+- automation level
+- evidence
+
+これは `docs/cleanup-architecture.md` の Required Evidence を、そのまま PR 面に写す運用である。
+
+### 7.2 Issue に残すもの
+
+current task で回収しないものは follow-up Issue に切り出す。
+
+使い分け:
+
+- micro cleanup だが current scope を超える: 単独 follow-up Issue 1 件
+- periodic cleanup: parent Issue を作り、child Issue に分割
+- detector-only signal: report を evidence にして triage 用 Issue へ接続
+
+Issue 本文には少なくとも次を含める。
+
+- trigger / category / source of truth / decision / scope / automation level / evidence
+- 必要なら `blocked by #...`
+- parent がある場合は `sub-issue of #...`
+
+### 7.3 Project に残すもの
+
+Project は backlog の倉庫ではなく active management 面として使う。
+したがって cleanup 系 Issue の Project 反映は次で分ける。
+
+- report-only / backlog 段階: 基本は Project に載せない
+- weekly triage で着手候補になった periodic cleanup: Project に追加して `Status` を更新する
+- active child を持つ parent cleanup issue: Epic として必要な間だけ残す
+- `Priority` は active/ready の cleanup issue に限って付ける
+
+dependency の扱い:
+
+- 実行順序を持つ分割は `sub-issue`
+- 直接 blocker がある場合だけ `blocked-by`
+- 文脈参照だけなら `refs`
+
+## 8. Recommended Operating Cadence
+
+実行 cadence は次を最小セットとする。
+
+| cadence | action | outcome |
+|---|---|---|
+| 毎 task | task-local loop で micro cleanup を即回収する | 局所 drift を backlog 化しすぎない |
+| 毎 review / handoff | review preflight で report を残す | safe fix 不能な signal を落とさない |
+| 毎 PR / branch check | CI report で機械観測結果を残す | 手元差以外の drift を継続可視化する |
+| 毎週 20 分 | weekly triage で report を整理し、Issue / Project に反映する | periodic cleanup を分割して active 管理へ接続する |
+
+## 9. Summary
+
+cleanup pipeline は、
+micro cleanup を「その場で bounded に回収する loop」へ、
+periodic cleanup を「report を蓄積して triage で分割する loop」へ分ける。
+
+この文書で固定したのは次の 4 点である。
+
+- 入力は task-local observation / deterministic baseline / structural constraints / doc drift detection の 4 群に分ける
+- 実行面は task-local loop / review preflight / CI report / weekly triage の 4 面に固定する
+- route は auto-fix / auto-report / manual triage の 3 種に分ける
+- 記録先は PR / Issue / Project を使い分け、cleanup evidence と dependency を残す


### PR DESCRIPTION
## 概要

cleanup を「思い出したらやる」運用ではなく、signal を決めて同じ流れで扱える loop にするための設計を追加しました。
今回の整理では、micro cleanup は作業中にその場で回収し、periodic cleanup は report をためて週次 triage で分割する、という役割分担を固定しています。

## 変更内容

- `docs/cleanup-pipeline.md` を追加し、入力 signal / 実行面 / 出力 / 記録先を整理
- `task-local loop` / `review preflight` / `CI report` / `weekly triage` の 4 つの実行面を定義
- `auto-fix` / `auto-report` / `manual triage` の境界を明文化
- cleanup の結果を PR / Issue / Project にどう残すかを整理
- 既存の cleanup architecture と README から新しい文書へ導線を追加

## ざっくり運用イメージ

- その場で正本が明確な小さいズレは、micro cleanup として今の PR で直す
- すぐ直せない detector 結果は、auto-report として evidence を残す
- 広い棚卸しが必要なものは、weekly triage で periodic cleanup の Issue に分ける

## 確認

- `ruff check .`
- `PYTHONPATH=src pytest`

Closes #264
