### PR TITLE
Cherry-pick dashboard input telemetry flow tracking to main

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -475,6 +475,63 @@ h2 { font-size: 1.1rem; margin-bottom: 0.75rem; }
 var DASHBOARD_FALLBACK_CANDIDATES = ["作業開始", "休憩", "移動", "食事", "作業完了"];
 var candidateTapMode = "compose";
 var dashboardBusy = false;
+var dashboardInputFlow = null;
+
+function newDashboardFlowId() {
+  return "dashboard-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
+}
+
+function resetDashboardInputFlow() {
+  dashboardInputFlow = null;
+}
+
+function startDashboardInputFlow(options) {
+  var next = options || {};
+  var mode = (next.mode || "").trim();
+  if (!mode) return null;
+  if (dashboardInputFlow && !next.force) return dashboardInputFlow;
+  var text = typeof next.text === "string" ? next.text : document.getElementById("log-text").value;
+  dashboardInputFlow = {
+    flowId: newDashboardFlowId(),
+    mode: mode,
+    trigger: (next.trigger || "").trim(),
+    candidateSource: (next.candidate_source || "").trim(),
+    initialText: text,
+    editedBeforeSubmit: false
+  };
+  postUiEvent("input_started", {
+    flow_id: dashboardInputFlow.flowId,
+    mode: dashboardInputFlow.mode,
+    trigger: dashboardInputFlow.trigger,
+    text_length: text.length,
+    candidate_source: dashboardInputFlow.candidateSource
+  });
+  return dashboardInputFlow;
+}
+
+function ensureDashboardInputFlow(options) {
+  if (dashboardInputFlow) return dashboardInputFlow;
+  return startDashboardInputFlow(options);
+}
+
+function buildDashboardFlowPayload(text, extraUiData) {
+  var flow = ensureDashboardInputFlow({
+    mode: extraUiData && extraUiData.mode ? extraUiData.mode : "text",
+    trigger: extraUiData && extraUiData.trigger ? extraUiData.trigger : "dashboard_submit",
+    candidate_source: extraUiData && extraUiData.candidate_source ? extraUiData.candidate_source : "",
+    text: text
+  });
+  var payload = Object.assign({}, extraUiData || {});
+  payload.flow_id = flow ? flow.flowId : "";
+  payload.mode = flow ? flow.mode : (payload.mode || "text");
+  payload.trigger = flow && flow.trigger ? flow.trigger : (payload.trigger || "dashboard_submit");
+  payload.edited_before_submit = flow ? flow.editedBeforeSubmit : !!payload.edited_before_submit;
+  payload.text_length = text.length;
+  if (flow && flow.candidateSource && !payload.candidate_source) {
+    payload.candidate_source = flow.candidateSource;
+  }
+  return payload;
+}
 
 function heatColor(n) {
   if (n === 0) return '#eeeeee';
@@ -578,6 +635,13 @@ function renderCandidates(items) {
         await saveCandidateQuickLog(text, source);
         return;
       }
+      startDashboardInputFlow({
+        mode: "tag",
+        trigger: "candidate_tag",
+        candidate_source: source,
+        text: text,
+        force: true
+      });
       var input = document.getElementById("log-text");
       input.value = text;
       if (typeof input.setSelectionRange === "function") {
@@ -666,6 +730,7 @@ async function refreshDashboard(source) {
 async function submitDashboardLogText(text, extraUiData) {
   var msg = document.getElementById("log-msg");
   if (!text || dashboardBusy) return false;
+  var telemetryData = buildDashboardFlowPayload(text, extraUiData);
   setDashboardBusy(true);
   msg.textContent = "保存しています...";
   msg.className = "";
@@ -680,15 +745,15 @@ async function submitDashboardLogText(text, extraUiData) {
       saved = true;
       msg.textContent = "保存しました: " + text;
       msg.className = "msg-ok";
-      await postUiEvent("save_success", Object.assign({
-        text_length: text.length
-      }, extraUiData || {}));
+      await postUiEvent("input_submitted", telemetryData);
+      await postUiEvent("save_success", telemetryData);
       try {
         await Promise.all([loadHeatmap(), loadCandidates(), loadSummaries()]);
       } catch (refreshEx) {
         msg.textContent = "保存済み。再取得に失敗しました。再試行してください。";
         msg.className = "msg-err";
       }
+      resetDashboardInputFlow();
       setTimeout(function() { if (msg.className === "msg-ok") { msg.textContent = ""; msg.className = ""; } }, 3000);
     } else {
       var err = await r.json();
@@ -696,14 +761,14 @@ async function submitDashboardLogText(text, extraUiData) {
       msg.className = "msg-err";
       await postUiEvent("save_error", Object.assign({
         status: r.status
-      }, extraUiData || {}));
+      }, telemetryData));
     }
   } catch (ex) {
     msg.textContent = "接続エラー: " + ex.message;
     msg.className = "msg-err";
     await postUiEvent("save_error", Object.assign({
       reason: "fetch_exception"
-    }, extraUiData || {}));
+    }, telemetryData));
   } finally {
     setDashboardBusy(false);
   }
@@ -726,7 +791,15 @@ async function submitDashboardLog() {
 }
 
 async function saveCandidateQuickLog(text, source) {
+  startDashboardInputFlow({
+    mode: "quick",
+    trigger: "candidate_quick_save",
+    candidate_source: source || "",
+    text: text,
+    force: true
+  });
   await submitDashboardLogText(text, {
+    mode: "quick",
     trigger: "candidate_quick_save",
     candidate_source: source || ""
   });
@@ -740,8 +813,24 @@ document.getElementById("candidate-quick-mode").addEventListener("click", functi
 });
 document.getElementById("log-submit").addEventListener("click", submitDashboardLog);
 document.getElementById("refresh-btn").addEventListener("click", function() { refreshDashboard("manual"); });
-document.getElementById("log-text").addEventListener("input", renderComposerState);
+document.getElementById("log-text").addEventListener("input", function() {
+  var input = document.getElementById("log-text");
+  var flow = ensureDashboardInputFlow({
+    mode: "text",
+    trigger: "dashboard_submit",
+    text: input.value
+  });
+  if (flow && flow.initialText !== input.value) {
+    flow.editedBeforeSubmit = true;
+  }
+  renderComposerState();
+});
 document.getElementById("log-text").addEventListener("focus", function() {
+  ensureDashboardInputFlow({
+    mode: "text",
+    trigger: "dashboard_submit",
+    text: document.getElementById("log-text").value
+  });
   setTimeout(function() {
     document.getElementById("log-form").scrollIntoView({ block: "nearest" });
   }, 120);

--- a/src/personal_mcp/tools/log_form.py
+++ b/src/personal_mcp/tools/log_form.py
@@ -32,6 +32,7 @@ INPUT_SUBMITTED_TRIGGER_BY_MODE: Dict[str, str] = {
 }
 DEFAULT_DOMAIN = "general"
 DEFAULT_KIND = "note"
+ALLOWED_INPUT_SUBMITTED_MODES: frozenset = frozenset(INPUT_SUBMITTED_SAVE_TYPE_BY_MODE)
 
 
 def suggest_labels(text: str) -> Dict[str, str]:
@@ -75,8 +76,17 @@ def _normalize_bool(value: Any) -> bool:
     return bool(value)
 
 
+def _resolve_input_submitted_mode(ui_mode: str, extra_data: Dict[str, Any]) -> str:
+    mode = str(extra_data.get("mode") or "").strip()
+    if not mode:
+        mode = ui_mode
+    if mode not in ALLOWED_INPUT_SUBMITTED_MODES:
+        raise ValueError(f"unsupported input mode: {mode}")
+    return mode
+
+
 def _input_submitted_contract_payload(ui_mode: str, extra_data: Dict[str, Any]) -> Dict[str, Any]:
-    mode = ui_mode
+    mode = _resolve_input_submitted_mode(ui_mode, extra_data)
     trigger = str(extra_data.get("trigger") or "").strip()
     if not trigger:
         trigger = INPUT_SUBMITTED_TRIGGER_BY_MODE[mode]

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -264,6 +264,17 @@ def test_http_get_dashboard_candidate_tap_script_exists(data_dir: Path) -> None:
     assert "tag.dataset.source = source;" in html
     assert "input.value = text;" in html
     assert "renderComposerState();" in html
+    assert "var dashboardInputFlow = null;" in html
+    assert "flow_id: dashboardInputFlow.flowId" in html
+    assert 'postUiEvent("input_started"' in html
+    assert 'await postUiEvent("input_submitted", telemetryData);' in html
+    assert 'await postUiEvent("save_success", telemetryData);' in html
+    assert 'mode: "tag"' in html
+    assert 'mode: "quick"' in html
+    assert 'trigger: "candidate_tag"' in html
+    assert 'trigger: "dashboard_submit"' in html
+    assert "flow.editedBeforeSubmit = true;" in html
+    assert "resetDashboardInputFlow();" in html
     assert 'await fetch("/api/candidates")' in html
 
 

--- a/tests/test_log_form.py
+++ b/tests/test_log_form.py
@@ -157,6 +157,37 @@ def test_ui_event_add_sqlite_input_submitted_applies_mode_defaults(
     assert rec["data"]["trigger"] == expected_trigger
 
 
+def test_ui_event_add_sqlite_input_submitted_dashboard_uses_explicit_mode(data_dir: Path) -> None:
+    rec = ui_event_add_sqlite(
+        event_name="input_submitted",
+        ui_mode="dashboard",
+        data_dir=str(data_dir),
+        extra_data={
+            "mode": "quick",
+            "trigger": "candidate_quick_save",
+            "candidate_source": "recent",
+            "flow_id": "dashboard-123",
+        },
+    )
+    assert rec["data"]["ui_mode"] == "dashboard"
+    assert rec["data"]["mode"] == "quick"
+    assert rec["data"]["save_type"] == "instant"
+    assert rec["data"]["edited_before_submit"] is False
+    assert rec["data"]["trigger"] == "candidate_quick_save"
+    assert rec["data"]["candidate_source"] == "recent"
+    assert rec["data"]["flow_id"] == "dashboard-123"
+
+
+def test_ui_event_add_sqlite_input_submitted_dashboard_rejects_missing_mode(data_dir: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported input mode"):
+        ui_event_add_sqlite(
+            event_name="input_submitted",
+            ui_mode="dashboard",
+            data_dir=str(data_dir),
+            extra_data={},
+        )
+
+
 # ---------------------------------------------------------------------------
 # append_sqlite / DB content
 # ---------------------------------------------------------------------------
@@ -403,6 +434,32 @@ def test_http_post_ui_events_input_submitted_fills_contract_defaults(data_dir: P
     assert body["data"]["save_type"] == "manual"
     assert body["data"]["edited_before_submit"] is True
     assert body["data"]["trigger"] == "candidate_tag"
+
+
+def test_http_post_ui_events_dashboard_accepts_explicit_input_mode(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    responses = _post_json(
+        handler_cls,
+        {
+            "event_name": "input_submitted",
+            "ui_mode": "dashboard",
+            "extra_data": {
+                "mode": "tag",
+                "trigger": "candidate_tag",
+                "candidate_source": "recent",
+                "edited_before_submit": True,
+            },
+        },
+        "/events/ui",
+    )
+    status, body = responses[0]
+    assert status == 201
+    assert body["data"]["ui_mode"] == "dashboard"
+    assert body["data"]["mode"] == "tag"
+    assert body["data"]["save_type"] == "manual"
+    assert body["data"]["trigger"] == "candidate_tag"
+    assert body["data"]["candidate_source"] == "recent"
+    assert body["data"]["edited_before_submit"] is True
 
 
 def test_make_html_shows_optional_labels_and_suggestion() -> None:


### PR DESCRIPTION
## Summary
- cherry-pick PR #295 equivalent changes onto main
- add dashboard input flow telemetry for quick, tag, and free text save paths
- keep advisor-only history out of the main merge path

## Testing
- PYTHONPATH=src pytest tests/test_log_form.py tests/test_heatmap_summary.py
- PYTHONPATH=src ruff check src/personal_mcp/tools/log_form.py src/personal_mcp/adapters/http_server.py tests/test_log_form.py tests/test_heatmap_summary.py

Refs #249