### PR TITLE
fix(ui): keep dashboard candidate_source explicit

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -495,7 +495,7 @@ function startDashboardInputFlow(options) {
     flowId: newDashboardFlowId(),
     mode: mode,
     trigger: (next.trigger || "").trim(),
-    candidateSource: (next.candidate_source || "").trim(),
+    candidateSource: resolveDashboardCandidateSource(mode, next.candidate_source || ""),
     initialText: text,
     editedBeforeSubmit: false
   };
@@ -514,11 +514,23 @@ function ensureDashboardInputFlow(options) {
   return startDashboardInputFlow(options);
 }
 
+function resolveDashboardCandidateSource(mode, candidateSource) {
+  var normalized = (candidateSource || "").trim();
+  if (normalized) return normalized;
+  if (mode === "text") return "free_text";
+  return "";
+}
+
 function buildDashboardFlowPayload(text, extraUiData) {
+  var mode = extraUiData && extraUiData.mode ? extraUiData.mode : "text";
+  var candidateSource = resolveDashboardCandidateSource(
+    mode,
+    extraUiData && extraUiData.candidate_source ? extraUiData.candidate_source : ""
+  );
   var flow = ensureDashboardInputFlow({
-    mode: extraUiData && extraUiData.mode ? extraUiData.mode : "text",
+    mode: mode,
     trigger: extraUiData && extraUiData.trigger ? extraUiData.trigger : "dashboard_submit",
-    candidate_source: extraUiData && extraUiData.candidate_source ? extraUiData.candidate_source : "",
+    candidate_source: candidateSource,
     text: text
   });
   var payload = Object.assign({}, extraUiData || {});
@@ -527,9 +539,9 @@ function buildDashboardFlowPayload(text, extraUiData) {
   payload.trigger = flow && flow.trigger ? flow.trigger : (payload.trigger || "dashboard_submit");
   payload.edited_before_submit = flow ? flow.editedBeforeSubmit : !!payload.edited_before_submit;
   payload.text_length = text.length;
-  if (flow && flow.candidateSource && !payload.candidate_source) {
-    payload.candidate_source = flow.candidateSource;
-  }
+  payload.candidate_source = flow
+    ? resolveDashboardCandidateSource(payload.mode, flow.candidateSource)
+    : candidateSource;
   return payload;
 }
 

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -265,10 +265,17 @@ def test_http_get_dashboard_candidate_tap_script_exists(data_dir: Path) -> None:
     assert "input.value = text;" in html
     assert "renderComposerState();" in html
     assert "var dashboardInputFlow = null;" in html
+    assert (
+        'candidateSource: resolveDashboardCandidateSource(mode, next.candidate_source || ""),'
+        in html
+    )
     assert "flow_id: dashboardInputFlow.flowId" in html
     assert 'postUiEvent("input_started"' in html
     assert 'await postUiEvent("input_submitted", telemetryData);' in html
     assert 'await postUiEvent("save_success", telemetryData);' in html
+    assert "function resolveDashboardCandidateSource(mode, candidateSource) {" in html
+    assert 'if (mode === "text") return "free_text";' in html
+    assert "payload.candidate_source = flow" in html
     assert 'mode: "tag"' in html
     assert 'mode: "quick"' in html
     assert 'trigger: "candidate_tag"' in html

--- a/tests/test_log_form.py
+++ b/tests/test_log_form.py
@@ -178,6 +178,28 @@ def test_ui_event_add_sqlite_input_submitted_dashboard_uses_explicit_mode(data_d
     assert rec["data"]["flow_id"] == "dashboard-123"
 
 
+def test_ui_event_add_sqlite_input_submitted_dashboard_accepts_free_text_candidate_source(
+    data_dir: Path,
+) -> None:
+    rec = ui_event_add_sqlite(
+        event_name="input_submitted",
+        ui_mode="dashboard",
+        data_dir=str(data_dir),
+        extra_data={
+            "mode": "text",
+            "trigger": "dashboard_submit",
+            "candidate_source": "free_text",
+            "flow_id": "dashboard-456",
+        },
+    )
+    assert rec["data"]["ui_mode"] == "dashboard"
+    assert rec["data"]["mode"] == "text"
+    assert rec["data"]["save_type"] == "manual"
+    assert rec["data"]["trigger"] == "dashboard_submit"
+    assert rec["data"]["candidate_source"] == "free_text"
+    assert rec["data"]["flow_id"] == "dashboard-456"
+
+
 def test_ui_event_add_sqlite_input_submitted_dashboard_rejects_missing_mode(data_dir: Path) -> None:
     with pytest.raises(ValueError, match="unsupported input mode"):
         ui_event_add_sqlite(
@@ -460,6 +482,32 @@ def test_http_post_ui_events_dashboard_accepts_explicit_input_mode(data_dir: Pat
     assert body["data"]["trigger"] == "candidate_tag"
     assert body["data"]["candidate_source"] == "recent"
     assert body["data"]["edited_before_submit"] is True
+
+
+def test_http_post_ui_events_dashboard_accepts_free_text_candidate_source(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    responses = _post_json(
+        handler_cls,
+        {
+            "event_name": "input_submitted",
+            "ui_mode": "dashboard",
+            "extra_data": {
+                "mode": "text",
+                "trigger": "dashboard_submit",
+                "candidate_source": "free_text",
+                "edited_before_submit": False,
+            },
+        },
+        "/events/ui",
+    )
+    status, body = responses[0]
+    assert status == 201
+    assert body["data"]["ui_mode"] == "dashboard"
+    assert body["data"]["mode"] == "text"
+    assert body["data"]["save_type"] == "manual"
+    assert body["data"]["trigger"] == "dashboard_submit"
+    assert body["data"]["candidate_source"] == "free_text"
+    assert body["data"]["edited_before_submit"] is False
 
 
 def test_make_html_shows_optional_labels_and_suggestion() -> None:


### PR DESCRIPTION
## Summary
- keep candidate_source present on dashboard telemetry payloads instead of dropping the key for free-text submits
- use free_text for dashboard free-input flows so input_started / input_submitted / save_success / save_error stay comparable
- add regression coverage for dashboard contract acceptance and rendered script expectations

## Why
- AC #249 requires a common comparable payload and says input_submitted should expose candidate_source
- missing keys made it hard to distinguish free text from dropped telemetry or older payloads downstream

## Free-text value
- candidate_source=free_text
- this keeps the field explicit without overloading empty string semantics

## Testing
- PYTHONPATH=src pytest tests/test_log_form.py tests/test_heatmap_summary.py -o cache_dir=/tmp/personal-mcp-core-pytest-cache-249-fix-post3
- PYTHONPATH=src ruff check src/personal_mcp/adapters/http_server.py tests/test_log_form.py tests/test_heatmap_summary.py --cache-dir /tmp/personal-mcp-core-ruff-cache-249-fix-3

Refs #249
