### PR TITLE
docs: align Ruff source-of-truth guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Install dev dependencies
         run: pip install -e ".[dev]"
 
+      # Ruff reads line-length and E501 policy from pyproject.toml.
+      # Keep CI free of CLI overrides so docs and local runs stay aligned.
       - name: ruff check
         run: ruff check .
 

--- a/AI_GUIDE.md
+++ b/AI_GUIDE.md
@@ -127,6 +127,12 @@
 - VSCode は worktree ごとに作業机を固定し、待機状態を `main + clean` に保ってください
 - 副作用の可否（実行権限）は運用都合よりも [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) を優先してください
 
+## Tooling source of truth
+
+- Ruff の `line-length` と `E501` 方針の正本は `pyproject.toml` です
+- `ruff check .` / `ruff format --check .` は `pyproject.toml` の設定をそのまま読む前提です
+- AI 向けガイドや runbook の記述と矛盾した場合は、Ruff 設定については `pyproject.toml` を優先してください
+
 ---
 
 ## 互換性に関するガードレール

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,14 @@ If a deletion is needed, provide:
 
 ```bash
 # Install in editable mode (development)
-pip install -e .
+pip install -e ".[dev]"
 
 # Run the entrypoint (prints loaded context length)
 python -m personal_mcp.server
+
+# Verify Ruff using pyproject.toml as the source of truth
+python -m ruff check .
+python -m ruff format --check .
 
 # Verify AI_GUIDE.md copies are in sync
 diff AI_GUIDE.md src/personal_mcp/AI_GUIDE.md
@@ -61,7 +65,8 @@ diff AI_GUIDE.md src/personal_mcp/AI_GUIDE.md
 
 Notes:
 
-* No test runner or linter is configured yet — the repo is intentionally minimal and evolving slowly.
+* Ruff and pytest are configured in this repo.
+* Ruff `line-length` and `E501` policy are defined in `pyproject.toml`; do not override them with CLI flags in docs or CI.
 
 ## Architecture
 

--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -130,14 +130,19 @@ git diff
 
 目的: lint / import / format 系の失敗を先に潰す。
 
+Ruff 設定の正本は `pyproject.toml` とする。
+`ruff check .` は lint rule failure を示し、`E501` を ignore していない限り line-length violation を含みうる。
+`ruff format --check .` は formatting drift を示し、line-length 設定の CLI 上書き有無とは別に読む。
+
 コマンド例:
 
 ```bash
 ruff --version
 ruff check .
+ruff format --check .
 ```
 
-期待結果: `ruff check .` が成功する。失敗時は対象ファイルとルールが特定できる。
+期待結果: `ruff check .` と `ruff format --check .` が成功する。失敗時は対象ファイルと rule / formatting drift が特定できる。
 
 次に進む条件: 成功、または最小修正で収まりそうと判断できる。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,14 @@ where = ["src"]
 personal_mcp = ["AI_GUIDE.md"]
 
 [tool.ruff]
+# Source of truth for Ruff line length used by both lint and format.
+# Keep CI/local commands free of CLI overrides so they read this file.
 line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
 # E: pycodestyle errors, F: pyflakes — minimal set, no docstring/type enforcement
+# E501 remains enabled unless it is explicitly added to ignore here.
 select = ["E", "F"]
 
 [tool.ruff.format]

--- a/src/personal_mcp/AI_GUIDE.md
+++ b/src/personal_mcp/AI_GUIDE.md
@@ -127,6 +127,12 @@
 - VSCode は worktree ごとに作業机を固定し、待機状態を `main + clean` に保ってください
 - 副作用の可否（実行権限）は運用都合よりも [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) を優先してください
 
+## Tooling source of truth
+
+- Ruff の `line-length` と `E501` 方針の正本は `pyproject.toml` です
+- `ruff check .` / `ruff format --check .` は `pyproject.toml` の設定をそのまま読む前提です
+- AI 向けガイドや runbook の記述と矛盾した場合は、Ruff 設定については `pyproject.toml` を優先してください
+
 ---
 
 ## 互換性に関するガードレール


### PR DESCRIPTION
## Summary
- document pyproject.toml as the source of truth for Ruff line-length and E501
- align AI-facing docs and the Codex runbook with the current Ruff and pytest workflow
- annotate CI so Ruff commands stay free of CLI overrides

## Validation
- `make guide-check`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `NOTIFY_CHANNEL=stdout python -m pytest`

## Notes
- plain `python -m pytest` in this shell picked up `NOTIFY_CHANNEL=discord`, which caused unrelated webhook tests to hit the network; the suite passed with `NOTIFY_CHANNEL=stdout`, matching the expected local stdout adapter behavior

Closes #299
