### PR TITLE
feat: unify fixed candidates for dashboard fallback

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -6,7 +6,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from personal_mcp.core.event import ALLOWED_DOMAINS
-from personal_mcp.tools.candidates import list_candidates
+from personal_mcp.tools.candidates import FIXED_CANDIDATES, list_candidates
 from personal_mcp.tools.daily_summary import (
     count_events_by_date,
     get_latest_summary,
@@ -347,7 +347,7 @@ renderSuggestion();
 </body>
 </html>"""
 
-_DASHBOARD_HTML = """\
+_DASHBOARD_HTML_TEMPLATE = """\
 <!DOCTYPE html>
 <html lang="ja">
 <head>
@@ -472,7 +472,7 @@ h2 { font-size: 1.1rem; margin-bottom: 0.75rem; }
 </div>
 <div id="summaries"></div>
 <script>
-var DASHBOARD_FALLBACK_CANDIDATES = ["作業開始", "休憩", "移動", "食事", "作業完了"];
+var DASHBOARD_FALLBACK_CANDIDATES = DASHBOARD_FALLBACK_CANDIDATES_JSON;
 var candidateTapMode = "compose";
 var dashboardBusy = false;
 var dashboardInputFlow = null;
@@ -861,6 +861,11 @@ loadSummaries();
 </script>
 </body>
 </html>"""  # noqa: E501
+
+_DASHBOARD_HTML = _DASHBOARD_HTML_TEMPLATE.replace(
+    "DASHBOARD_FALLBACK_CANDIDATES_JSON",
+    json.dumps(list(FIXED_CANDIDATES), ensure_ascii=False),
+)
 
 
 def _make_html() -> str:

--- a/src/personal_mcp/tools/candidates.py
+++ b/src/personal_mcp/tools/candidates.py
@@ -31,6 +31,8 @@ _CANDIDATE_STOPWORDS = frozenset(
 )
 _CANDIDATE_POS2 = frozenset({"普通名詞", "固有名詞", "数詞"})
 _tagger: Optional[Any] = None
+# Keep this set aligned with docs/daily-input-ux-mvp.md section 4.4:
+# prefer everyday vocabulary and avoid domain-specific or honorific wording.
 FIXED_CANDIDATES: tuple[str, ...] = (
     "作業開始",
     "作業再開",

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -88,6 +88,11 @@ def test_list_candidates_cold_start_returns_fixed_only(data_dir: Path) -> None:
     assert got == expected
 
 
+def test_fixed_candidates_contract() -> None:
+    assert 0 < len(FIXED_CANDIDATES) <= 8
+    assert all(0 < len(text) <= MAX_CANDIDATE_LENGTH for text in FIXED_CANDIDATES)
+
+
 @pytest.mark.parametrize("count", [7, 8])
 def test_list_candidates_threshold_7_and_8_enable_non_fixed_sources(
     data_dir: Path, count: int

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import io
+import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from personal_mcp.core.event import build_v1_record
 from personal_mcp.storage.sqlite import append_sqlite
+from personal_mcp.tools.candidates import FIXED_CANDIDATES
 from personal_mcp.tools.daily_summary import (
     count_events_by_date,
     generate_daily_summary,
@@ -283,6 +285,13 @@ def test_http_get_dashboard_candidate_tap_script_exists(data_dir: Path) -> None:
     assert "flow.editedBeforeSubmit = true;" in html
     assert "resetDashboardInputFlow();" in html
     assert 'await fetch("/api/candidates")' in html
+
+
+def test_http_get_dashboard_fallback_candidates_match_fixed_candidates(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    _, _, html = _do_get_html(handler_cls, "/dashboard")
+    expected = json.dumps(list(FIXED_CANDIDATES), ensure_ascii=False)
+    assert f"var DASHBOARD_FALLBACK_CANDIDATES = {expected};" in html
 
 
 def test_http_get_dashboard_has_sticky_composer_and_enter_submit(data_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- What changed: backend の `FIXED_CANDIDATES` を dashboard fallback の単一ソースにし、HTML へ JSON 埋め込みする形に変更しました。fixed 候補の件数上限・長さ制約テストと、dashboard fallback が fixed 候補と一致する契約テストを追加しました。
- Why: cold start の `/api/candidates` と dashboard の API failure fallback で候補語彙と順序が分かれていたためです。Closes #250.

## Validation
- python: `Python 3.10.12`
- ruff: `ruff 0.15.5`
- pytest: `pytest 9.0.2`
- `ruff check src/personal_mcp/tools/candidates.py src/personal_mcp/adapters/http_server.py tests/test_candidates.py tests/test_heatmap_summary.py`: `pass`
- `PYTHONPATH=src pytest tests/test_candidates.py tests/test_heatmap_summary.py`: `45 passed, 12 skipped`

## Review Notes
- Scope: fixed 候補の単一ソース化と、その契約テスト追加に限定しています。
- Behavior change: dashboard fallback が backend と同じ 8 件の fixed 候補を同順で表示するようになります。
- Risks: dashboard HTML は module import 時に fixed 候補 JSON を埋め込むため、将来 fixed 候補の供給方法を動的化する場合はここを見直す必要があります。
- Mitigation: 候補配列の一致を HTML テストで固定し、件数・長さ制約も unit test で固定しました。

## Minimal Fix
- Applied: `FIXED_CANDIDATES` を正本のまま export し、dashboard 側のハードコード配列を削除しました。
- Reason: issue の acceptance criteria を満たす最小差分で、既存 API/UI 構造を変えずに揃えるためです。

## Next Issues
- None
