### PR TITLE
fix(test): make pytest subprocess imports work without install

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ make test
 
 `make setup` は `python -m pip install -e ".[dev]"` の薄いラッパーなので、optional dependency の `dev` を毎回思い出さなくてよい。
 
+project 自体の editable install は、`pytest` を動かすための前提ではない。テスト時の import 補助は [`tests/conftest.py`](./tests/conftest.py) で行っている。
+
 ```bash
 # 開発用インストール
 make setup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,19 @@
-import pytest
+import os
+import sys
 from pathlib import Path
+
+import pytest
+
+
+_SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+_SRC_DIR_STR = str(_SRC_DIR)
+if _SRC_DIR_STR not in sys.path:
+    sys.path.insert(0, _SRC_DIR_STR)
+
+_existing_pythonpath = os.environ.get("PYTHONPATH", "")
+_pythonpath_entries = [entry for entry in _existing_pythonpath.split(os.pathsep) if entry]
+if _SRC_DIR_STR not in _pythonpath_entries:
+    os.environ["PYTHONPATH"] = os.pathsep.join([_SRC_DIR_STR, *_pythonpath_entries])
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add src to sys.path during pytest startup
- propagate the same path through PYTHONPATH so subprocess-based CLI tests inherit it
- note in README that editable install is not required just to run pytest

## Verification
- ruff check tests/conftest.py README.md
- pytest tests/test_cli.py
- pytest
