### PR TITLE
fix: reset quick log mode after one save

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -576,7 +576,7 @@ function renderCandidateMode() {
   document.getElementById("candidate-quick-mode").classList.toggle("active", !composeActive);
   document.getElementById("candidate-mode-hint").textContent = composeActive
     ? "候補タグをタップすると入力欄に入り、内容を確認してから保存できます。"
-    : "Quickログ ON: 候補タグをタップするとそのまま保存します。";
+    : "Quickログ: 次の候補タップ 1 回だけ即保存します。";
 }
 
 function currentDraftText() {
@@ -815,6 +815,7 @@ async function saveCandidateQuickLog(text, source) {
     trigger: "candidate_quick_save",
     candidate_source: source || ""
   });
+  setCandidateTapMode("compose");
 }
 
 document.getElementById("candidate-compose-mode").addEventListener("click", function() {

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -302,3 +302,20 @@ def test_http_get_dashboard_has_sticky_composer_and_enter_submit(data_dir: Path)
     assert 'enterkeyhint="done"' in html
     assert 'document.getElementById("log-text").addEventListener("keydown"' in html
     assert 'btn.textContent = "保存中...";' in html
+
+
+def test_dashboard_quick_mode_armed_resets_to_compose_after_save(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    _, _, html = _do_get_html(handler_cls, "/dashboard")
+    # Hint text communicates one-shot armed mode (not sticky toggle)
+    assert "次の候補タップ 1 回だけ即保存します" in html
+    # Default candidateTapMode is compose; quick mode does not persist across page loads
+    assert 'var candidateTapMode = "compose";' in html
+    # setCandidateTapMode("compose") is called inside saveCandidateQuickLog,
+    # ensuring mode resets after request completes (both success and failure paths)
+    fn_start = html.find("async function saveCandidateQuickLog(")
+    fn_end = html.find('document.getElementById("candidate-compose-mode")', fn_start)
+    assert fn_start != -1, "saveCandidateQuickLog not found in dashboard HTML"
+    assert fn_end != -1, "boundary after saveCandidateQuickLog not found"
+    fn_body = html[fn_start:fn_end]
+    assert 'setCandidateTapMode("compose");' in fn_body


### PR DESCRIPTION
## Summary
- reset dashboard candidate tap mode back to `compose` after each quick save request completes
- update the quick mode hint text to clearly describe one-shot armed behavior
- add a dashboard HTML test that locks the reset call into `saveCandidateQuickLog`

## Testing
- `python -m pytest -q tests/test_heatmap_summary.py`
- `python -m ruff check .`
- `python -m pytest -q` *(currently has unrelated baseline failures in `tests/test_candidates.py`, `tests/test_codex_notify.py`, and `tests/test_notify_wrapper.py`)*

Closes #251
