### PR TITLE
refactor(storage): move GitHub dedup off JSONL compat

### DIFF
--- a/docs/eng-ingest-impl.md
+++ b/docs/eng-ingest-impl.md
@@ -28,7 +28,7 @@
 | 取得対象 | GitHub API `/users/{username}/events` first page（最大 100 件） |
 | 出力 | Event Contract v1 レコード、`domain: "eng"` 固定 |
 | source 値 | `"github"` 固定 |
-| dedup キー | `data.github_event_id`（既存 `source: "github"` レコードから検索） |
+| dedup キー | `data.github_event_id` → storage boundary で `"github:{id}"` に正規化し DB UNIQUE 制約で担保（#307） |
 | skip 対象 | `WatchEvent` / `PublicEvent` / `MemberEvent` |
 
 **責務の限界（MVP 意図どおり）:**

--- a/src/personal_mcp/storage/events_store.py
+++ b/src/personal_mcp/storage/events_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from personal_mcp.storage.jsonl import read_jsonl
 from personal_mcp.storage.path import resolve_data_dir
@@ -17,10 +17,17 @@ def _paths(data_dir: Optional[str]) -> tuple[Path, Path]:
     return resolved / PRIMARY_STORAGE, resolved / COMPAT_STORAGE
 
 
-def append_event(record: Dict[str, Any], data_dir: Optional[str] = None) -> None:
-    """Write an event to the runtime primary storage."""
+def append_event(
+    record: Dict[str, Any], data_dir: Optional[str] = None
+) -> Literal["saved", "skipped"]:
+    """Write an event to the runtime primary storage.
+
+    Returns 'saved' on new insert, 'skipped' if a duplicate dedup_key exists.
+    Dedup responsibility is at the storage boundary; callers should not
+    pre-filter duplicates by reading existing records.
+    """
     db_path, _ = _paths(data_dir)
-    append_sqlite(db_path, record)
+    return append_sqlite(db_path, record)
 
 
 def read_events(data_dir: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -79,7 +86,14 @@ def rebuild_db_from_jsonl(data_dir: Optional[str] = None, dry_run: bool = False)
 
     if db_path.exists():
         db_path.unlink()
+    written_count = 0
+    skipped_count = 0
     for record in source_records:
-        append_sqlite(db_path, record)
-    result["written_count"] = len(source_records)
+        outcome = append_sqlite(db_path, record)
+        if outcome == "saved":
+            written_count += 1
+        else:
+            skipped_count += 1
+    result["written_count"] = written_count
+    result["skipped_count"] = skipped_count
     return result

--- a/src/personal_mcp/storage/sqlite.py
+++ b/src/personal_mcp/storage/sqlite.py
@@ -3,35 +3,108 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal, Optional
 
-_DDL = """
+_CREATE_TABLE_DDL = """
 CREATE TABLE IF NOT EXISTS events (
-    id     INTEGER PRIMARY KEY AUTOINCREMENT,
-    ts     TEXT NOT NULL,
-    domain TEXT NOT NULL,
-    kind   TEXT,
-    raw    TEXT NOT NULL
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts         TEXT NOT NULL,
+    domain     TEXT NOT NULL,
+    kind       TEXT,
+    dedup_key  TEXT,
+    raw        TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts);
 CREATE INDEX IF NOT EXISTS idx_events_domain ON events (domain);
 """
 
+_DEDUP_INDEX_DDL = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_events_dedup_key"
+    " ON events (dedup_key) WHERE dedup_key IS NOT NULL;"
+)
 
-def append_sqlite(db_path: Path, record: Dict[str, Any]) -> None:
+
+def _github_dedup_key(record: Dict[str, Any]) -> Optional[str]:
+    """Return a stable dedup key for GitHub events, or None for other sources.
+
+    The key space is shared across github_sync and github_ingest so that
+    events written by either tool are deduplicated against each other.
+    """
+    if record.get("source") == "github":
+        eid = record.get("data", {}).get("github_event_id")
+        if eid:
+            return f"github:{eid}"
+    return None
+
+
+def _backfill_dedup_keys(conn: sqlite3.Connection) -> None:
+    """Populate missing dedup keys for rows created before the #307 schema.
+
+    If older DBs already contain multiple rows for the same GitHub event, only
+    the earliest row is backfilled. Later duplicates keep NULL so history is
+    preserved while future inserts are still blocked by the keyed row.
+    """
+    existing_keys = {
+        dedup_key
+        for (dedup_key,) in conn.execute("SELECT dedup_key FROM events WHERE dedup_key IS NOT NULL")
+    }
+    updates: list[tuple[str, int]] = []
+    for row_id, raw in conn.execute(
+        "SELECT id, raw FROM events WHERE dedup_key IS NULL ORDER BY id ASC"
+    ):
+        try:
+            record = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        dedup_key = _github_dedup_key(record)
+        if dedup_key and dedup_key not in existing_keys:
+            updates.append((dedup_key, row_id))
+            existing_keys.add(dedup_key)
+    if updates:
+        conn.executemany("UPDATE events SET dedup_key = ? WHERE id = ?", updates)
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    """Initialize or migrate schema.
+
+    - Creates the events table with dedup_key column if it does not exist.
+    - Adds dedup_key column to pre-#307 databases via ALTER TABLE.
+    - Backfills missing GitHub dedup keys from stored raw records.
+    - Creates a partial UNIQUE index on non-NULL dedup_key values.
+    """
+    conn.executescript(_CREATE_TABLE_DDL)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(events)")}
+    if "dedup_key" not in cols:
+        conn.executescript("ALTER TABLE events ADD COLUMN dedup_key TEXT;")
+    _backfill_dedup_keys(conn)
+    conn.executescript(_DEDUP_INDEX_DDL)
+
+
+def append_sqlite(db_path: Path, record: Dict[str, Any]) -> Literal["saved", "skipped"]:
+    """Insert record into SQLite DB.
+
+    Returns 'saved' when the row is newly inserted.
+    Returns 'skipped' when a row with the same dedup_key already exists
+    (duplicate GitHub event).  Non-GitHub records (dedup_key=None) are
+    always saved because SQLite treats each NULL as distinct.
+    """
     db_path.parent.mkdir(parents=True, exist_ok=True)
+    dedup_key = _github_dedup_key(record)
     with sqlite3.connect(str(db_path)) as conn:
-        conn.executescript(_DDL)
-        conn.execute(
-            "INSERT INTO events (ts, domain, kind, raw) VALUES (?, ?, ?, ?)",
+        _ensure_schema(conn)
+        cursor = conn.execute(
+            "INSERT OR IGNORE INTO events (ts, domain, kind, dedup_key, raw)"
+            " VALUES (?, ?, ?, ?, ?)",
             (
                 record.get("ts"),
                 record.get("domain"),
                 record.get("kind"),
+                dedup_key,
                 json.dumps(record, ensure_ascii=False),
             ),
         )
         conn.commit()
+    return "saved" if cursor.rowcount == 1 else "skipped"
 
 
 def read_sqlite(db_path: Path) -> List[Dict[str, Any]]:

--- a/src/personal_mcp/tools/github_ingest.py
+++ b/src/personal_mcp/tools/github_ingest.py
@@ -5,15 +5,17 @@ Responsibility boundary vs github_sync (#147):
   github_sync (#147) — existing manual-sync MVP
     - reads /users/{username}/events first page (up to 100)
     - minimal data.* payload: github_event_id only as extra field
-    - dedup reads runtime storage (`events.db`) via storage boundary
+    - dedup via storage boundary DB UNIQUE constraint on dedup_key
 
   github_ingest (#247) — full spec implementation (docs/eng-ingest-impl.md)
     - same /users/{username}/events endpoint
     - rich data.* payload per Section 3.3
-    - dedup reads runtime storage (`events.db`) via storage boundary
+    - dedup via storage boundary DB UNIQUE constraint on dedup_key
     - insert-only / skip per Section 3.4
 
 Both use source="github" and data.github_event_id for dedup.
+The storage boundary normalizes each event to a canonical dedup_key
+("github:{github_event_id}") and enforces uniqueness via DB constraint.
 Events saved by either tool share the same dedup key space.
 """
 
@@ -21,10 +23,10 @@ from __future__ import annotations
 
 import json
 import urllib.request
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from personal_mcp.core.event import build_v1_record
-from personal_mcp.storage.events_store import append_event, read_events
+from personal_mcp.storage.events_store import append_event
 
 
 _SKIP_TYPES: frozenset = frozenset({"WatchEvent", "PublicEvent", "MemberEvent"})
@@ -156,17 +158,6 @@ def _map_github_event(gh_event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     )
 
 
-def _load_existing_github_event_ids(data_dir: Optional[str]) -> Set[str]:
-    """Return github_event_id values stored in the runtime primary storage."""
-    ids: Set[str] = set()
-    for r in read_events(data_dir):
-        if r.get("source") == "github":
-            eid = r.get("data", {}).get("github_event_id")
-            if eid:
-                ids.add(str(eid))
-    return ids
-
-
 def github_ingest(
     username: str,
     token: Optional[str] = None,
@@ -175,11 +166,11 @@ def github_ingest(
     """Fetch GitHub user events and append new ones via storage boundary.
 
     Implements the eng ingest spec (docs/eng-ingest-impl.md Section 2–5).
-    Dedup is insert-only / skip per Section 3.4.
+    Dedup is insert-only / skip per Section 3.4, enforced by DB UNIQUE
+    constraint on dedup_key at the storage boundary; no pre-read is done.
 
     Returns {"saved": int, "skipped": int, "failed": int}.
     """
-    existing_ids = _load_existing_github_event_ids(data_dir)
     try:
         gh_events = _fetch_github_events(username, token)
     except Exception:
@@ -190,18 +181,16 @@ def github_ingest(
 
     saved = skipped = failed = 0
     for gh_event in gh_events:
-        event_id = str(gh_event.get("id", ""))
-        if event_id in existing_ids:
-            skipped += 1
-            continue
         try:
             record = _map_github_event(gh_event)
             if record is None:
                 skipped += 1
                 continue
-            append_event(record, data_dir=data_dir)
-            existing_ids.add(event_id)
-            saved += 1
+            outcome = append_event(record, data_dir=data_dir)
+            if outcome == "saved":
+                saved += 1
+            else:
+                skipped += 1
         except Exception:
             failed += 1
 

--- a/src/personal_mcp/tools/github_sync.py
+++ b/src/personal_mcp/tools/github_sync.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import json
 import urllib.request
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from personal_mcp.core.event import build_v1_record
-from personal_mcp.storage.events_store import append_event, read_events
+from personal_mcp.storage.events_store import append_event
 
 
 _SKIP_TYPES: frozenset = frozenset({"WatchEvent", "PublicEvent", "MemberEvent"})
@@ -96,17 +96,6 @@ def _map_event_to_record(gh_event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     )
 
 
-def _load_existing_github_event_ids(data_dir: Optional[str]) -> Set[str]:
-    """Return github_event_id values stored in the runtime primary storage."""
-    ids: Set[str] = set()
-    for r in read_events(data_dir):
-        if r.get("source") == "github":
-            eid = r.get("data", {}).get("github_event_id")
-            if eid:
-                ids.add(str(eid))
-    return ids
-
-
 def github_sync(
     username: str,
     token: Optional[str] = None,
@@ -115,8 +104,9 @@ def github_sync(
     """Fetch GitHub user events and append new ones via storage boundary.
 
     Returns {"saved": int, "skipped": int, "failed": int}.
+    Dedup is handled at the storage boundary via DB UNIQUE constraint on
+    dedup_key; no pre-read of existing records is performed.
     """
-    existing_ids = _load_existing_github_event_ids(data_dir)
     try:
         gh_events = _fetch_github_events(username, token)
     except Exception:
@@ -127,18 +117,16 @@ def github_sync(
 
     saved = skipped = failed = 0
     for gh_event in gh_events:
-        event_id = str(gh_event.get("id", ""))
-        if event_id in existing_ids:
-            skipped += 1
-            continue
         try:
             record = _map_event_to_record(gh_event)
             if record is None:
                 skipped += 1
                 continue
-            append_event(record, data_dir=data_dir)
-            existing_ids.add(event_id)
-            saved += 1
+            outcome = append_event(record, data_dir=data_dir)
+            if outcome == "saved":
+                saved += 1
+            else:
+                skipped += 1
         except Exception:
             failed += 1
 

--- a/tests/test_github_ingest.py
+++ b/tests/test_github_ingest.py
@@ -13,13 +13,13 @@ Verifies:
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any, Dict
 
 from personal_mcp.storage.events_store import append_event, rebuild_db_from_jsonl
 from personal_mcp.storage.sqlite import read_sqlite
 from personal_mcp.tools.github_ingest import (
-    _load_existing_github_event_ids,
     _map_github_event,
     _normalize_ts,
     github_ingest,
@@ -33,6 +33,34 @@ from personal_mcp.tools.github_ingest import (
 
 def _read_runtime_events(data_dir: Path) -> list[dict]:
     return read_sqlite(data_dir / "events.db")
+
+
+def _insert_pre307_row(data_dir: Path, record: Dict[str, Any]) -> None:
+    db_path = data_dir / "events.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL,
+                domain TEXT NOT NULL,
+                kind TEXT,
+                raw TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts);
+            CREATE INDEX IF NOT EXISTS idx_events_domain ON events (domain);
+            """
+        )
+        conn.execute(
+            "INSERT INTO events (ts, domain, kind, raw) VALUES (?, ?, ?, ?)",
+            (
+                record["ts"],
+                record["domain"],
+                record["kind"],
+                json.dumps(record, ensure_ascii=False),
+            ),
+        )
+        conn.commit()
 
 
 def _push_event(event_id: str = "100") -> Dict[str, Any]:
@@ -336,73 +364,39 @@ def test_map_fallback_without_repo_returns_none() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _load_existing_github_event_ids
+# DB dedup key — storage boundary (Issue #307)
 # ---------------------------------------------------------------------------
 
 
-def test_load_ids_returns_empty_when_no_events(data_dir: Path) -> None:
-    assert _load_existing_github_event_ids(str(data_dir)) == set()
+def test_github_ingest_dedup_key_stored_in_db(data_dir: Path, monkeypatch) -> None:
+    """Storage boundary writes dedup_key='github:EVENT_ID' into the DB row."""
+    import personal_mcp.tools.github_ingest as mod
+
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+    github_ingest(username="user", data_dir=str(data_dir))
+
+    db_path = data_dir / "events.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        row = conn.execute("SELECT dedup_key FROM events WHERE dedup_key IS NOT NULL").fetchone()
+    assert row is not None
+    assert row[0] == "github:100"
 
 
-def test_load_ids_returns_github_source_ids(data_dir: Path) -> None:
-    github_event = {
-        "v": 1,
-        "ts": "2026-03-07T10:00:00+00:00",
-        "domain": "eng",
-        "kind": "artifact",
-        "data": {"text": "x", "github_event_id": "abc"},
-        "tags": [],
-        "source": "github",
-    }
-    manual_event = {
-        "v": 1,
-        "ts": "2026-03-07T10:00:00+00:00",
-        "domain": "eng",
-        "kind": "note",
-        "data": {"text": "manual"},
-        "tags": [],
-        "source": "manual",
-    }
-    append_event(github_event, data_dir=str(data_dir))
-    append_event(manual_event, data_dir=str(data_dir))
-    assert _load_existing_github_event_ids(str(data_dir)) == {"abc"}
+def test_github_ingest_idempotent_on_retry(data_dir: Path, monkeypatch) -> None:
+    """Calling github_ingest twice with the same events returns saved=0 on the second call."""
+    import personal_mcp.tools.github_ingest as mod
 
-
-def test_load_ids_after_recovery_migration_includes_github_rows(data_dir: Path) -> None:
-    append_event(
-        {
-            "v": 1,
-            "ts": "2026-03-07T10:00:00+00:00",
-            "domain": "general",
-            "kind": "note",
-            "data": {"text": "db row"},
-            "tags": [],
-            "source": "manual",
-        },
-        data_dir=str(data_dir),
+    monkeypatch.setattr(
+        mod,
+        "_fetch_github_events",
+        lambda u, t: [_push_event("100"), _issues_event("closed", "200")],
     )
-    manual_event = {
-        "v": 1,
-        "ts": "2026-03-07T10:00:00+00:00",
-        "domain": "general",
-        "kind": "note",
-        "data": {"text": "db row"},
-        "tags": [],
-        "source": "manual",
-    }
-    github_jsonl_only = {
-        "v": 1,
-        "ts": "2026-03-07T10:00:00+00:00",
-        "domain": "eng",
-        "kind": "artifact",
-        "data": {"text": "legacy", "github_event_id": "abc"},
-        "tags": [],
-        "source": "github",
-    }
-    _write_events(data_dir / "events.jsonl", [manual_event, github_jsonl_only])
-    rebuild_db_from_jsonl(data_dir=str(data_dir))
+    first = github_ingest(username="user", data_dir=str(data_dir))
+    second = github_ingest(username="user", data_dir=str(data_dir))
 
-    assert _load_existing_github_event_ids(str(data_dir)) == {"abc"}
+    assert first == {"saved": 2, "skipped": 0, "failed": 0}
+    assert second == {"saved": 0, "skipped": 2, "failed": 0}
+    assert len(_read_runtime_events(data_dir)) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -445,6 +439,30 @@ def test_github_ingest_skips_duplicate(data_dir: Path, monkeypatch) -> None:
 
     assert result["saved"] == 0
     assert result["skipped"] == 1
+    assert len(_read_runtime_events(data_dir)) == 1
+
+
+def test_github_ingest_skips_duplicate_in_pre307_db(data_dir: Path, monkeypatch) -> None:
+    import personal_mcp.tools.github_ingest as mod
+
+    existing = {
+        "v": 1,
+        "ts": "2026-03-07T10:00:00+00:00",
+        "domain": "eng",
+        "kind": "artifact",
+        "data": {"text": "already saved", "github_event_id": "100"},
+        "tags": [],
+        "source": "github",
+    }
+    _insert_pre307_row(data_dir, existing)
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+
+    result = github_ingest(username="user", data_dir=str(data_dir))
+
+    assert result == {"saved": 0, "skipped": 1, "failed": 0}
+    with sqlite3.connect(str(data_dir / "events.db")) as conn:
+        rows = conn.execute("SELECT dedup_key FROM events ORDER BY id ASC").fetchall()
+    assert rows == [("github:100",)]
     assert len(_read_runtime_events(data_dir)) == 1
 
 

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any, Dict
 
 from personal_mcp.storage.events_store import append_event, rebuild_db_from_jsonl
 from personal_mcp.storage.sqlite import read_sqlite
 from personal_mcp.tools.github_sync import (
-    _load_existing_github_event_ids,
     _map_event_to_record,
     _normalize_ts,
     github_sync,
@@ -25,6 +25,34 @@ def _write_events(path: Path, events: list) -> None:
 
 def _read_runtime_events(data_dir: Path) -> list[dict]:
     return read_sqlite(data_dir / "events.db")
+
+
+def _insert_pre307_row(data_dir: Path, record: Dict[str, Any]) -> None:
+    db_path = data_dir / "events.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL,
+                domain TEXT NOT NULL,
+                kind TEXT,
+                raw TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts);
+            CREATE INDEX IF NOT EXISTS idx_events_domain ON events (domain);
+            """
+        )
+        conn.execute(
+            "INSERT INTO events (ts, domain, kind, raw) VALUES (?, ?, ?, ?)",
+            (
+                record["ts"],
+                record["domain"],
+                record["kind"],
+                json.dumps(record, ensure_ascii=False),
+            ),
+        )
+        conn.commit()
 
 
 def _push_event(event_id: str = "100") -> Dict[str, Any]:
@@ -133,36 +161,69 @@ def test_map_watch_event_returns_none() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _load_existing_github_event_ids
+# DB dedup key — storage boundary (Issue #307)
 # ---------------------------------------------------------------------------
 
 
-def test_load_ids_returns_empty_when_file_missing(data_dir: Path) -> None:
-    assert _load_existing_github_event_ids(str(data_dir)) == set()
+def test_github_sync_dedup_key_stored_in_db(data_dir: Path, monkeypatch) -> None:
+    """Storage boundary writes dedup_key='github:EVENT_ID' into the DB row."""
+    import personal_mcp.tools.github_sync as mod
+
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+    github_sync(username="user", data_dir=str(data_dir))
+
+    db_path = data_dir / "events.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        row = conn.execute("SELECT dedup_key FROM events WHERE dedup_key IS NOT NULL").fetchone()
+    assert row is not None
+    assert row[0] == "github:100"
 
 
-def test_load_ids_returns_only_github_source_ids(data_dir: Path) -> None:
-    github_event = {
+def test_github_sync_idempotent_on_retry(data_dir: Path, monkeypatch) -> None:
+    """Calling github_sync twice with the same events returns saved=0 on the second call."""
+    import personal_mcp.tools.github_sync as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_fetch_github_events",
+        lambda u, t: [_push_event("100"), _issues_event("closed", "200")],
+    )
+    first = github_sync(username="user", data_dir=str(data_dir))
+    second = github_sync(username="user", data_dir=str(data_dir))
+
+    assert first == {"saved": 2, "skipped": 0, "failed": 0}
+    assert second == {"saved": 0, "skipped": 2, "failed": 0}
+    assert len(_read_runtime_events(data_dir)) == 2
+
+
+def test_github_sync_skips_event_already_saved_by_github_ingest(
+    data_dir: Path, monkeypatch
+) -> None:
+    """Events saved by github_ingest must not be re-synced (cross-dedup regression)."""
+    import personal_mcp.tools.github_sync as mod
+
+    ingest_record = {
         "v": 1,
         "ts": "2026-03-07T10:00:00+00:00",
         "domain": "eng",
         "kind": "artifact",
-        "data": {"text": "x", "github_event_id": "abc"},
+        "data": {
+            "text": "pushed 1 commit(s) to user/repo (main)",
+            "github_event_id": "100",
+            "github_event_type": "PushEvent",
+            "repo_full_name": "user/repo",
+        },
         "tags": [],
         "source": "github",
     }
-    manual_event = {
-        "v": 1,
-        "ts": "2026-03-07T10:00:00+00:00",
-        "domain": "eng",
-        "kind": "note",
-        "data": {"text": "manual entry"},
-        "tags": [],
-        "source": "manual",
-    }
-    append_event(github_event, data_dir=str(data_dir))
-    append_event(manual_event, data_dir=str(data_dir))
-    assert _load_existing_github_event_ids(str(data_dir)) == {"abc"}
+    append_event(ingest_record, data_dir=str(data_dir))
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+
+    result = github_sync(username="user", data_dir=str(data_dir))
+
+    assert result["saved"] == 0
+    assert result["skipped"] == 1
+    assert len(_read_runtime_events(data_dir)) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +287,30 @@ def test_github_sync_skips_duplicate_when_id_exists_only_in_db(data_dir: Path, m
     assert result["skipped"] == 1
     rows = _read_runtime_events(data_dir)
     assert len(rows) == 1
+
+
+def test_github_sync_skips_duplicate_in_pre307_db(data_dir: Path, monkeypatch) -> None:
+    import personal_mcp.tools.github_sync as mod
+
+    existing = {
+        "v": 1,
+        "ts": "2026-03-07T10:00:00+00:00",
+        "domain": "eng",
+        "kind": "artifact",
+        "data": {"text": "already saved", "github_event_id": "100"},
+        "tags": [],
+        "source": "github",
+    }
+    _insert_pre307_row(data_dir, existing)
+    monkeypatch.setattr(mod, "_fetch_github_events", lambda u, t: [_push_event("100")])
+
+    result = github_sync(username="user", data_dir=str(data_dir))
+
+    assert result == {"saved": 0, "skipped": 1, "failed": 0}
+    with sqlite3.connect(str(data_dir / "events.db")) as conn:
+        rows = conn.execute("SELECT dedup_key FROM events ORDER BY id ASC").fetchall()
+    assert rows == [("github:100",)]
+    assert len(_read_runtime_events(data_dir)) == 1
 
 
 def test_github_sync_skips_duplicate_after_recovery_migration(data_dir: Path, monkeypatch) -> None:

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -23,6 +23,33 @@ def _write_events(path: Path, events: list[dict]) -> None:
     )
 
 
+def _insert_pre307_row(db_path: Path, record: dict) -> None:
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL,
+                domain TEXT NOT NULL,
+                kind TEXT,
+                raw TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts);
+            CREATE INDEX IF NOT EXISTS idx_events_domain ON events (domain);
+            """
+        )
+        conn.execute(
+            "INSERT INTO events (ts, domain, kind, raw) VALUES (?, ?, ?, ?)",
+            (
+                record["ts"],
+                record["domain"],
+                record["kind"],
+                json.dumps(record, ensure_ascii=False),
+            ),
+        )
+        conn.commit()
+
+
 def test_rebuild_jsonl_from_db_dry_run_and_apply(data_dir: Path) -> None:
     db_path = data_dir / "events.db"
     jsonl_path = data_dir / "events.jsonl"
@@ -121,6 +148,59 @@ def test_rebuild_db_from_jsonl_dry_run_and_apply_with_legacy_normalization(data_
     assert len(rows) == 2
     assert rows[0]["data"]["text"] == "legacy entry"
     assert rows[1]["data"]["text"] == "v1 entry"
+
+
+def test_append_sqlite_backfills_pre307_github_dedup_key(data_dir: Path) -> None:
+    db_path = data_dir / "events.db"
+    existing = {
+        "v": 1,
+        "ts": "2026-03-07T10:00:00+00:00",
+        "domain": "eng",
+        "kind": "artifact",
+        "data": {"text": "already saved", "github_event_id": "100"},
+        "tags": [],
+        "source": "github",
+    }
+    _insert_pre307_row(db_path, existing)
+
+    outcome = append_sqlite(db_path, existing)
+
+    assert outcome == "skipped"
+    assert len(read_sqlite(db_path)) == 1
+    with sqlite3.connect(str(db_path)) as conn:
+        rows = conn.execute("SELECT id, dedup_key FROM events ORDER BY id ASC").fetchall()
+    assert rows == [(1, "github:100")]
+
+
+def test_rebuild_db_from_jsonl_reports_actual_written_count_after_dedup(
+    data_dir: Path,
+) -> None:
+    duplicate = {
+        "v": 1,
+        "ts": "2026-03-07T10:00:00+00:00",
+        "domain": "eng",
+        "kind": "artifact",
+        "data": {"text": "duplicate", "github_event_id": "100"},
+        "tags": [],
+        "source": "github",
+    }
+    manual = {
+        "v": 1,
+        "ts": "2026-03-07T11:00:00+00:00",
+        "domain": "general",
+        "kind": "note",
+        "data": {"text": "manual"},
+        "tags": [],
+        "source": "manual",
+    }
+    _write_events(data_dir / "events.jsonl", [duplicate, duplicate, manual])
+
+    applied = rebuild_db_from_jsonl(data_dir=str(data_dir))
+
+    assert applied["source_count"] == 3
+    assert applied["written_count"] == 2
+    assert applied["skipped_count"] == 1
+    assert len(read_sqlite(data_dir / "events.db")) == 2
 
 
 def test_cli_storage_migration_dry_run_json_output(


### PR DESCRIPTION
## Summary
- What changed: moved GitHub dedup enforcement fully to the SQLite storage boundary, backfilled canonical dedup keys for pre-#307 databases, and made `rebuild_db_from_jsonl()` report actual saved vs skipped rows.
- Why: the original #307 change still let migrated pre-#307 DB rows bypass duplicate skipping on the first retry/sync, and recovery reports overstated writes when dedup skipped duplicates.

## Validation
- python: `Python 3.10.12`
- ruff: `ruff 0.15.5`
- pytest: `pytest 9.0.2`
- `python -m ruff check .`: pass
- `python -m ruff format --check .`: pass
- `python -m pytest`: pass

## Review Notes
- Scope: limited to issue #307 follow-up fixes in storage migration/reporting and related regression tests.
- Behavior change: pre-#307 SQLite DBs now backfill one canonical `github:{event_id}` dedup key per existing GitHub event before new inserts, so the first post-migration sync/ingest skips duplicates as intended.
- Risks: older DBs that already contain multiple rows for the same GitHub event will keep only the earliest row keyed; later historical duplicates remain with `NULL` dedup keys.
- Mitigation: this preserves existing history without destructive cleanup while still blocking future duplicate inserts; regression coverage was added for pre-#307 DBs and rebuild counts.

## Minimal Fix
- Applied: added dedup-key backfill in `src/personal_mcp/storage/sqlite.py`, counted rebuild outcomes in `src/personal_mcp/storage/events_store.py`, and added migration regressions in `tests/test_storage_migration.py`, `tests/test_github_sync.py`, and `tests/test_github_ingest.py`.
- Reason: these were the direct causes of the review failures; no design or scope expansion was needed.

## Next Issues
- None

Closes #307
