### PR TITLE
Clarify JSONL restore semantics

### DIFF
--- a/docs/infra/restore-mvp-draft.md
+++ b/docs/infra/restore-mvp-draft.md
@@ -130,6 +130,11 @@ personal-mcp storage-db-to-jsonl --data-dir <data-dir>
 personal-mcp storage-jsonl-to-db --data-dir <data-dir>
 ```
 
+> **Note**: `storage-jsonl-to-db` は JSONL の内容を **忠実に再構築** する（dedup なし）。
+> JSONL に重複レコードが含まれる場合、DB にも同数のレコードが挿入される。
+> 将来の重複排除は runtime の `github-sync` / `github-ingest` が担う。
+> この挙動は「復元はデータの回収であり、内容の修正ではない」という原則と一致する。
+
 ### 4. `event-list` で読み取れることを確認する
 
 ```sh

--- a/src/personal_mcp/server.py
+++ b/src/personal_mcp/server.py
@@ -178,7 +178,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_db_to_jsonl.add_argument("--json", action="store_true")
     p_jsonl_to_db = sub.add_parser(
         "storage-jsonl-to-db",
-        help="recovery-only: regenerate events.db from events.jsonl",
+        help=(
+            "recovery-only: faithful reconstruction of events.db "
+            "from events.jsonl (no dedup applied)"
+        ),
     )
     p_jsonl_to_db.add_argument("--data-dir", default=None)
     p_jsonl_to_db.add_argument("--dry-run", action="store_true")

--- a/src/personal_mcp/storage/events_store.py
+++ b/src/personal_mcp/storage/events_store.py
@@ -58,7 +58,13 @@ def rebuild_jsonl_from_db(data_dir: Optional[str] = None, dry_run: bool = False)
 
 
 def rebuild_db_from_jsonl(data_dir: Optional[str] = None, dry_run: bool = False) -> Dict[str, Any]:
-    """Regenerate primary DB from compatibility JSONL records."""
+    """Regenerate primary DB from compatibility JSONL records.
+
+    Semantics: faithful reconstruction with no deduplication.
+    All JSONL records are inserted as-is, so duplicate records in JSONL are
+    preserved in the regenerated DB. Runtime dedup remains the responsibility
+    of github_sync / github_ingest.
+    """
     db_path, jsonl_path = _paths(data_dir)
     if not jsonl_path.exists():
         raise FileNotFoundError(f"missing source file: {jsonl_path}")

--- a/tests/test_storage_migration.py
+++ b/tests/test_storage_migration.py
@@ -179,3 +179,25 @@ def test_cli_storage_db_to_jsonl_returns_error_when_source_missing(
     captured = capsys.readouterr()
     assert rc == 1
     assert "missing source file" in captured.out
+
+
+def test_rebuild_db_from_jsonl_preserves_duplicates(data_dir: Path) -> None:
+    """Faithful reconstruction keeps duplicate JSONL rows in the DB."""
+    jsonl_path = data_dir / "events.jsonl"
+    db_path = data_dir / "events.db"
+    dup_event = {
+        "v": 1,
+        "ts": "2026-03-08T06:00:00+00:00",
+        "domain": "eng",
+        "kind": "artifact",
+        "data": {"text": "dup", "github_event_id": "999"},
+        "tags": [],
+        "source": "github",
+    }
+    _write_events(jsonl_path, [dup_event, dup_event])
+
+    result = rebuild_db_from_jsonl(data_dir=str(data_dir))
+
+    assert result["written_count"] == 2
+    rows = read_sqlite(db_path)
+    assert len(rows) == 2


### PR DESCRIPTION
## Summary
- clarify that `storage-jsonl-to-db` / `rebuild_db_from_jsonl()` perform faithful reconstruction with no dedup
- document the same recovery semantics in the restore runbook
- add a regression test proving duplicate JSONL rows are preserved in the rebuilt DB

Closes #325

## Testing
- `python -m ruff check .`
- `pytest` *(currently fails on existing baseline issues in `tests/test_codex_notify.py` and `tests/test_notify_wrapper.py`)*
