### PR TITLE
docs: clarify routing responsibilities across AI docs

### DIFF
--- a/AI_GUIDE.md
+++ b/AI_GUIDE.md
@@ -11,6 +11,8 @@
 
 ---
 
+> **文書責務**: AI 行動原則・姿勢の**正本**。役割境界の正本は [`docs/AI_ROLE_POLICY.md`](./docs/AI_ROLE_POLICY.md) であり、本文書はその**導線**（再定義しない）。runtime 別 runbook 詳細設計・通知運用は scope 外。
+
 ## 基本姿勢（最優先）
 
 - このリポジトリの所有者は、人間です
@@ -119,6 +121,7 @@
 - 正本は [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) です（この節と `CLAUDE.md` は導線です）
 - この節・`CLAUDE.md`・運用メモの記述が正本と矛盾する場合、正本を優先し、副作用を伴う作業は一旦停止して人間 Maintainer にエスカレーションしてください
 - 旧ルール参照による誤停止を避けるため、判断基準は常に正本に固定してください
+- runtime 別 runbook の詳細設計・通知運用は正本の非ゴール（scope 外）です
 
 ## AI作業環境運用（Git / worktree / VSCode）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ If this file, `AI_GUIDE.md`, old templates, or historical comments conflict with
 
 To avoid false stops caused by stale wording, never treat non-authoritative role notes as a blocker by themselves.
 
+`CLAUDE.md` is a routing document for Claude Code — it provides constraints and routes to authoritative sources. It does not replicate role boundary definitions, runtime runbooks, or notification operations.
+
 ## Practical guardrails for Claude Code
 
 When working in this repo, treat the following as hard constraints:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,8 @@
 > This document describes the system structure of `personal-mcp-core`.
 > For design principles and AI behavior rules, see `AI_GUIDE.md`.
 > For Claude Code-specific instructions, see `CLAUDE.md`.
+> For role boundaries and the authoritative role split policy, see [`docs/AI_ROLE_POLICY.md`](./AI_ROLE_POLICY.md).
+> This document covers system structure only; role boundaries, operational rules, and notification operations are not in scope here.
 
 ## Overview
 

--- a/src/personal_mcp/AI_GUIDE.md
+++ b/src/personal_mcp/AI_GUIDE.md
@@ -11,6 +11,8 @@
 
 ---
 
+> **文書責務**: AI 行動原則・姿勢の**正本**。役割境界の正本は [`docs/AI_ROLE_POLICY.md`](./docs/AI_ROLE_POLICY.md) であり、本文書はその**導線**（再定義しない）。runtime 別 runbook 詳細設計・通知運用は scope 外。
+
 ## 基本姿勢（最優先）
 
 - このリポジトリの所有者は、人間です
@@ -119,6 +121,7 @@
 - 正本は [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) です（この節と `CLAUDE.md` は導線です）
 - この節・`CLAUDE.md`・運用メモの記述が正本と矛盾する場合、正本を優先し、副作用を伴う作業は一旦停止して人間 Maintainer にエスカレーションしてください
 - 旧ルール参照による誤停止を避けるため、判断基準は常に正本に固定してください
+- runtime 別 runbook の詳細設計・通知運用は正本の非ゴール（scope 外）です
 
 ## AI作業環境運用（Git / worktree / VSCode）
 


### PR DESCRIPTION
## Summary
- cherry-pick the issue #311 docs routing responsibility changes from builder onto main
- clarify that AI_GUIDE.md is the source of truth for AI behavior while role boundaries stay in docs/AI_ROLE_POLICY.md
- state that CLAUDE.md and docs/architecture.md are routing/structure docs and do not define runtime runbooks or notification operations

## Testing
- diff -u AI_GUIDE.md src/personal_mcp/AI_GUIDE.md
- python -m ruff check .

Closes #311