### PR TITLE
heatmap: scale_population boundary seam のテストと docs を整理

### DIFF
--- a/docs/heatmap-state-density-spec.md
+++ b/docs/heatmap-state-density-spec.md
@@ -114,6 +114,26 @@ data contract / aggregation seam を導入する issue として扱う。
 - `raw_count` / `shipped_density` の再定義
 - relative scale の consumer や UI 色分け変更（#257 系で扱う）
 
+### `source` フィルタと `observation_model` / `boundary_date` の分担
+
+`source != "web-form-ui"` と `data.observation_model` / `boundary_date` は、同じ問題を別の層で扱う。
+
+| 仕組み | 役割 | この issue での扱い |
+|---|---|---|
+| `source != "web-form-ui"` | shipped `/api/heatmap` の `display_population` を定義する | #317 実装済み。#343 でも変更しない |
+| `data.observation_model = "current"` | 新規 writer が current observation model に属することを明示する | metadata contract として保持する |
+| `boundary_date` | historical records を scale 用の fallback で切り分ける | `scale_population` を絞る seam として使う |
+
+設計上の関係:
+
+- `display_population` は現行 shipped semantics のまま維持する
+- `scale_population` は `display_population` を土台にしつつ、必要なら `boundary_date` でさらに狭める
+- historical records の扱いは `source` や legacy payload shape から暗黙推定せず、明示的な boundary で制御する
+
+そのため #343 は telemetry 除外ロジックを置き換える issue ではなく、
+`source != "web-form-ui"` で決まる表示用集合に対して、
+scale 用の母集団を別条件で扱えるようにする issue と位置づける。
+
 ---
 
 ## 4. Telemetry の扱い — 3案比較と採否

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -44,16 +44,6 @@ def _add_event(db_path: Path, domain: str = "mood", ts: str | None = None) -> No
     append_sqlite(db_path, record)
 
 
-def _add_telemetry_event(db_path: Path, ts: str | None = None) -> None:
-    """Add a UI telemetry event (source="web-form-ui") excluded by shipped_density."""
-    if ts is None:
-        ts = datetime.now(timezone.utc).isoformat()
-    record = build_v1_record(
-        ts=ts, domain="general", text="x", tags=[], kind="interaction", source="web-form-ui"
-    )
-    append_sqlite(db_path, record)
-
-
 def _append_summary(db_path: Path, date_str: str, text: str = "summary") -> None:
     record = build_v1_record(
         ts=datetime.now(timezone.utc).isoformat(),
@@ -68,6 +58,7 @@ def _append_summary(db_path: Path, date_str: str, text: str = "summary") -> None
 
 
 def _add_telemetry_event(db_path: Path, ts: str | None = None) -> None:
+    """Add a UI telemetry event matching ui_event_add_sqlite output."""
     if ts is None:
         ts = datetime.now(timezone.utc).isoformat()
     record = build_v1_record(
@@ -216,8 +207,11 @@ def test_filtered_counter_supports_future_scale_window_without_changing_display(
     data_dir: Path,
 ) -> None:
     db_path = data_dir / "events.db"
-    _add_event(db_path, ts=_date_days_ago(2) + "T12:00:00+00:00")
-    _add_event(db_path, ts=datetime.now(timezone.utc).isoformat())
+    now_local = datetime.now().astimezone().replace(microsecond=0)
+    old_local = (now_local - timedelta(days=2)).replace(hour=12, minute=0, second=0)
+    current_local = now_local.replace(hour=12, minute=0, second=0)
+    _add_event(db_path, ts=old_local.astimezone(timezone.utc).isoformat())
+    _add_event(db_path, ts=current_local.astimezone(timezone.utc).isoformat())
     rows = read_events(data_dir=str(data_dir))
 
     display = _count_events_by_date_filtered(rows, 28, _is_display_population_record)
@@ -227,12 +221,44 @@ def test_filtered_counter_supports_future_scale_window_without_changing_display(
         lambda record: _is_scale_population_record(record, boundary_date=_today_local()),
     )
 
-    today = _today_local()
-    old_day = (datetime.now().astimezone().date() - timedelta(days=2)).isoformat()
+    today = current_local.date().isoformat()
+    old_day = old_local.date().isoformat()
     assert next(item for item in display if item["date"] == today)["count"] == 1
     assert next(item for item in display if item["date"] == old_day)["count"] == 1
     assert next(item for item in scale_window if item["date"] == today)["count"] == 1
     assert next(item for item in scale_window if item["date"] == old_day)["count"] == 0
+
+
+def test_scale_population_boundary_ignores_pre_boundary_high_count_days(data_dir: Path) -> None:
+    """Boundary filtering must keep old display counts out of scale calibration.
+
+    #317 already excludes `source="web-form-ui"` telemetry from shipped density.
+    #343 adds the seam for a narrower scale population, so the remaining risk is
+    pre-boundary display counts dominating the scale max.
+    """
+    db_path = data_dir / "events.db"
+    now_local = datetime.now().astimezone().replace(microsecond=0)
+    old_local = (now_local - timedelta(days=5)).replace(hour=12, minute=0, second=0)
+    current_local = now_local.replace(hour=12, minute=0, second=0)
+    boundary = (now_local.date() - timedelta(days=1)).isoformat()
+
+    for _ in range(10):
+        _add_event(db_path, ts=old_local.astimezone(timezone.utc).isoformat())
+    _add_event(db_path, ts=current_local.astimezone(timezone.utc).isoformat())
+
+    rows = read_events(data_dir=str(data_dir))
+    display = _count_events_by_date_filtered(rows, 28, _is_display_population_record)
+    scale_window = _count_events_by_date_filtered(
+        rows, 28, lambda record: _is_scale_population_record(record, boundary_date=boundary)
+    )
+
+    old_day = old_local.date().isoformat()
+    today = current_local.date().isoformat()
+    assert next(item for item in display if item["date"] == old_day)["count"] == 10
+    assert next(item for item in display if item["date"] == today)["count"] == 1
+    assert next(item for item in scale_window if item["date"] == old_day)["count"] == 0
+    assert next(item for item in scale_window if item["date"] == today)["count"] == 1
+    assert max(item["count"] for item in scale_window) == 1
 
 
 def test_count_events_by_date_excludes_web_form_ui_source(data_dir: Path) -> None:


### PR DESCRIPTION
## 概要
- `scale_population` の boundary seam を、現行実装に沿ったテストで明示しました
- UTC/local の日付ずれで不安定だった既存テストを、ローカル日付基準にそろえました
- `source != "web-form-ui"`、`data.observation_model`、`boundary_date` の役割分担を docs に追記しました

## 背景
レビュー時の指摘は次の 2 点でした。

- 新規テストが「legacy telemetry」と言い切っていたが、実際に検証しているのは `display_population` を土台にした `scale_population` の boundary 挙動だった
- UTC 日付文字列と local day bucket を混在させていて、タイムゾーン次第でテストがぶれる余地があった

この PR では、Findings の内容に合わせてテストの対象と説明を整理しています。

## 変更内容
- `tests/test_heatmap_summary.py`
  - 重複していた `_add_telemetry_event` の古い定義を削除
  - `test_filtered_counter_supports_future_scale_window_without_changing_display` を local date 基準に修正
  - `test_scale_population_boundary_ignores_pre_boundary_high_count_days` を追加し、pre-boundary の高件数日が scale max を支配しないことを確認
- `docs/heatmap-state-density-spec.md`
  - `source` フィルタ / `observation_model` / `boundary_date` の分担を追記
  - #343 が telemetry 除外ロジックの置き換えではなく、scale 用の母集団を別条件で扱う issue であることを明記

## テスト
- `python -m ruff check tests/test_heatmap_summary.py`
- `python -m pytest tests/test_heatmap_summary.py -v`

Refs #343
