### PR TITLE
Rename project to orange-garden

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# personal-mcp-core
+# orange-garden
+
+A personal observability garden for life events, annotations, and AI agents.
 
 ## What is this
+
 
 個人の活動をローカルに append-only で記録する、CLI ベースのセルフ観測ツール。
 ゲームセッション・気分・作業ログなどを共通の Event Contract v1 レコードとして扱い、runtime では `events.db` に保存してタイムライン表示やドメイン別フィルタリングができる。


### PR DESCRIPTION
## Summary

Rename the project from `personal-mcp-core` to **orange-garden**.

This project has evolved beyond a technical "core" component and is becoming a long-lived personal observability system.
The new name reflects the idea of a **software bonsai** — a garden where life events, annotations, interpretations, and AI agents gradually grow over time.

## Changes

* Rename repository concept to **orange-garden**
* Update README title and description
* Rename local directory
* Update references where needed

## Motivation

The previous name (`personal-mcp-core`) described the initial architecture but felt too narrow for the current direction.

The project is evolving into a broader system for:

* observing life events
* attaching annotations
* running AI interpretation
* visualizing activity (e.g., heatmaps / grass)

The name **orange-garden** represents a place where these elements grow organically over time.

## Notes

* No functional changes
* No API or behavior changes
* Purely a naming / documentation update

## Future Direction

This repository is intended to grow as a long-lived **software bonsai**, gradually expanding around personal observability, event logging, and AI-assisted interpretation.
