### PR TITLE
feat: dashboard heatmap を 365 日 grid に対応

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -356,11 +356,11 @@ _DASHBOARD_HTML_TEMPLATE = """\
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>活動</title>
 <style>
-body { --heatmap-cell-size: 6px; --heatmap-gap: 1px; font-family: system-ui; max-width: 480px; margin: 0 auto; padding: 1rem; }
+body { --heatmap-cell-size: clamp(24px, 3.4vh, 29px); --heatmap-gap: 2px; font-family: system-ui; max-width: 480px; margin: 0 auto; padding: 1rem; }
 h2 { font-size: 1.1rem; margin-bottom: 0.75rem; }
 .heatmap-scroll { overflow-x: auto; overflow-y: hidden; margin-bottom: 1.25rem; -webkit-overflow-scrolling: touch; }
 .heatmap { display: grid; grid-auto-flow: column; grid-template-rows: repeat(7, var(--heatmap-cell-size)); grid-auto-columns: var(--heatmap-cell-size); gap: var(--heatmap-gap); width: max-content; }
-.heatmap-cell { width: var(--heatmap-cell-size); height: var(--heatmap-cell-size); border-radius: 1px; }
+.heatmap-cell { width: var(--heatmap-cell-size); height: var(--heatmap-cell-size); border-radius: 2px; }
 .heatmap-cell-empty { background: transparent; }
 #candidates { margin-bottom: 1rem; display: flex; flex-wrap: wrap; gap: 0.5rem; }
 .candidate-tag {

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -511,7 +511,7 @@ def test_http_get_dashboard_candidate_tap_script_exists(data_dir: Path) -> None:
 def test_http_get_dashboard_heatmap_uses_365_day_grid_contract(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
     _, _, html = _do_get_html(handler_cls, "/dashboard")
-    assert "body { --heatmap-cell-size: 6px; --heatmap-gap: 1px;" in html
+    assert "body { --heatmap-cell-size: clamp(24px, 3.4vh, 29px); --heatmap-gap: 2px;" in html
     assert ".heatmap-scroll { overflow-x: auto; overflow-y: hidden;" in html
     assert ".heatmap { display: grid; grid-auto-flow: column;" in html
     assert "grid-template-rows: repeat(7, var(--heatmap-cell-size));" in html


### PR DESCRIPTION
## 関連Issue
- Closes #357
- Refs #353

## 概要
- 変更内容:
  - `/api/heatmap` に `days` query param を追加し、正の整数のみ受け付けるようにしました
  - `/dashboard` の heatmap 取得を `days=365` に切り替え、week x weekday の grid + 横スクロール表示に変更しました
  - 365 日表示と `days` 異常系を固定するテストを追加しました
- 理由:
  - Issue #357 の方針どおり、API default 28 日を維持しつつ dashboard だけ先に 365 日表示へ移行するためです

## 検証
- python:
  - 追加なし
- ruff:
  - `ruff check src/personal_mcp/adapters/http_server.py tests/test_heatmap_summary.py`
- pytest:
  - `pytest tests/test_heatmap_summary.py`
- `ruff check .`:
  - 未実行
- `pytest`:
  - 未実行

## レビューノート
- スコープ:
  - `/api/heatmap` の入力契約、dashboard heatmap の取得と描画、関連テストに限定しています
- 挙動変更:
  - `/dashboard` は 365 日 heatmap を横スクロール前提で表示します
  - `/api/heatmap` は `days` に不正値が来た場合 `400 Bad Request` を返します
- リスク:
  - heatmap grid shaping は HTML 内インライン JS 実装のため、UI 実地確認は別途必要です
- 緩和策:
  - API 異常系、365 日取得、dashboard HTML の grid 契約をテストで固定しています

## 最小修正
- 適用内容:
  - 既存 `count_events_by_date(days)` を再利用し、handler と dashboard テンプレートのみ最小差分で更新しました
- 理由:
  - scope 外の palette / bucket / debug API 拡張を避けるためです

## 次のIssue
- なし
