### PR TITLE
feat: centralize discord notification routing

### DIFF
--- a/scripts/notify
+++ b/scripts/notify
@@ -11,6 +11,9 @@ SOURCE="${NOTIFY_SOURCE:-}"
 READ_STDIN="0"
 CHANNEL_ARG_SET="0"
 EVENT_ARG_SET="0"
+ADAPTER_CHANNEL=""
+DISCORD_WEBHOOK_ENV_NAME=""
+DISCORD_WEBHOOK_SECRET_FILE=""
 
 notification_kind_event() {
   case "$1" in
@@ -29,13 +32,33 @@ notification_kind_event() {
   esac
 }
 
-notification_kind_channel() {
+notification_kind_route() {
   case "$1" in
     smoke_test)
       printf '%s' "discord-test"
       ;;
     *)
       printf '%s' ""
+      ;;
+  esac
+}
+
+resolve_notification_route() {
+  local logical_channel="$1"
+
+  ADAPTER_CHANNEL="$logical_channel"
+  DISCORD_WEBHOOK_ENV_NAME=""
+  DISCORD_WEBHOOK_SECRET_FILE=""
+
+  case "$logical_channel" in
+    discord)
+      DISCORD_WEBHOOK_ENV_NAME="DISCORD_WEBHOOK_AI_STATUS"
+      DISCORD_WEBHOOK_SECRET_FILE="$HOME/.config/secrets/discord_webhook.env"
+      ;;
+    discord-test)
+      ADAPTER_CHANNEL="discord"
+      DISCORD_WEBHOOK_ENV_NAME="DISCORD_WEBHOOK_AI_STATUS_TEST"
+      DISCORD_WEBHOOK_SECRET_FILE="$HOME/.config/secrets/discord_test_webhook.env"
       ;;
   esac
 }
@@ -112,9 +135,9 @@ if [[ -n "$KIND" ]]; then
     exit 2
   fi
 
-  resolved_channel="$(notification_kind_channel "$KIND")"
-  if [[ -n "$resolved_channel" ]]; then
-    CHANNEL="$resolved_channel"
+  resolved_route="$(notification_kind_route "$KIND")"
+  if [[ -n "$resolved_route" ]]; then
+    CHANNEL="$resolved_route"
   fi
 fi
 
@@ -138,7 +161,9 @@ if [[ -z "$MESSAGE" ]]; then
   exit 2
 fi
 
-ADAPTER_PATH="$CHANNEL_DIR/$CHANNEL"
+resolve_notification_route "$CHANNEL"
+
+ADAPTER_PATH="$CHANNEL_DIR/$ADAPTER_CHANNEL"
 if [[ ! -f "$ADAPTER_PATH" ]]; then
   echo "notify: channel adapter not found: $CHANNEL ($ADAPTER_PATH)" >&2
   exit 2
@@ -154,6 +179,13 @@ export NOTIFY_MESSAGE="$MESSAGE"
 export NOTIFY_TITLE="$TITLE"
 export NOTIFY_EVENT="$EVENT"
 export NOTIFY_SOURCE="$SOURCE"
+if [[ -n "$DISCORD_WEBHOOK_ENV_NAME" ]]; then
+  export NOTIFY_DISCORD_WEBHOOK_ENV_NAME="$DISCORD_WEBHOOK_ENV_NAME"
+  export NOTIFY_DISCORD_WEBHOOK_SECRET_FILE="$DISCORD_WEBHOOK_SECRET_FILE"
+else
+  unset NOTIFY_DISCORD_WEBHOOK_ENV_NAME || true
+  unset NOTIFY_DISCORD_WEBHOOK_SECRET_FILE || true
+fi
 
 # Send the normalized message over stdin as well as env vars so adapters can
 # choose the mechanism that fits the target platform best.

--- a/scripts/notify.d/discord
+++ b/scripts/notify.d/discord
@@ -4,6 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_discord_webhook.sh"
 
+webhook_env_name="${NOTIFY_DISCORD_WEBHOOK_ENV_NAME:-DISCORD_WEBHOOK_AI_STATUS}"
+secret_file="${NOTIFY_DISCORD_WEBHOOK_SECRET_FILE:-$HOME/.config/secrets/discord_webhook.env}"
+
 send_discord_webhook_notification \
-  "DISCORD_WEBHOOK_AI_STATUS" \
-  "$HOME/.config/secrets/discord_webhook.env"
+  "$webhook_env_name" \
+  "$secret_file"

--- a/scripts/notify.d/discord-test
+++ b/scripts/notify.d/discord-test
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Reuse the same Discord payload and POST path as the prod adapter.
-source "$SCRIPT_DIR/_discord_webhook.sh"
-
-send_discord_webhook_notification \
-  "DISCORD_WEBHOOK_AI_STATUS_TEST" \
-  "$HOME/.config/secrets/discord_test_webhook.env"
+# Keep the dedicated adapter path working, but route it through the shared
+# Discord delivery script with the test destination selected centrally.
+export NOTIFY_DISCORD_WEBHOOK_ENV_NAME="${NOTIFY_DISCORD_WEBHOOK_ENV_NAME:-DISCORD_WEBHOOK_AI_STATUS_TEST}"
+export NOTIFY_DISCORD_WEBHOOK_SECRET_FILE="${NOTIFY_DISCORD_WEBHOOK_SECRET_FILE:-$HOME/.config/secrets/discord_test_webhook.env}"
+exec "$SCRIPT_DIR/discord"

--- a/tests/test_codex_notify.py
+++ b/tests/test_codex_notify.py
@@ -80,7 +80,7 @@ def test_codex_notify_preserves_unknown_payload_type_as_event() -> None:
 
 
 def test_codex_notify_smoke_test_flag_routes_to_discord_test(tmp_path: Path) -> None:
-    adapter = tmp_path / "discord-test"
+    adapter = tmp_path / "discord"
     adapter.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"

--- a/tests/test_notify_wrapper.py
+++ b/tests/test_notify_wrapper.py
@@ -108,15 +108,17 @@ def test_notify_kind_can_override_channel(tmp_path: Path) -> None:
     )
     capture.chmod(capture.stat().st_mode | stat.S_IXUSR)
 
-    discord_test = tmp_path / "discord-test"
-    discord_test.write_text(
+    discord = tmp_path / "discord"
+    discord.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
         "printf 'channel=%s\\n' \"$NOTIFY_CHANNEL_NAME\"\n"
-        "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n",
+        "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n"
+        "printf 'webhook_env=%s\\n' \"$NOTIFY_DISCORD_WEBHOOK_ENV_NAME\"\n"
+        "printf 'secret_file=%s\\n' \"$NOTIFY_DISCORD_WEBHOOK_SECRET_FILE\"\n",
         encoding="utf-8",
     )
-    discord_test.chmod(discord_test.stat().st_mode | stat.S_IXUSR)
+    discord.chmod(discord.stat().st_mode | stat.S_IXUSR)
 
     result = _run_notify(
         "--kind",
@@ -131,6 +133,38 @@ def test_notify_kind_can_override_channel(tmp_path: Path) -> None:
     assert result.stdout.splitlines() == [
         "channel=discord-test",
         "event=task_completed",
+        "webhook_env=DISCORD_WEBHOOK_AI_STATUS_TEST",
+        f"secret_file={Path.home()}/.config/secrets/discord_test_webhook.env",
+    ]
+
+
+def test_notify_channel_alias_routes_discord_test_through_discord_adapter(tmp_path: Path) -> None:
+    discord = tmp_path / "discord"
+    discord.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf 'channel=%s\\n' \"$NOTIFY_CHANNEL_NAME\"\n"
+        "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n"
+        "printf 'webhook_env=%s\\n' \"$NOTIFY_DISCORD_WEBHOOK_ENV_NAME\"\n"
+        "printf 'secret_file=%s\\n' \"$NOTIFY_DISCORD_WEBHOOK_SECRET_FILE\"\n",
+        encoding="utf-8",
+    )
+    discord.chmod(discord.stat().st_mode | stat.S_IXUSR)
+
+    result = _run_notify(
+        "--channel",
+        "discord-test",
+        "--event",
+        "task-complete",
+        "smoke done",
+        env={"NOTIFY_CHANNEL_DIR": str(tmp_path)},
+    )
+
+    assert result.stdout.splitlines() == [
+        "channel=discord-test",
+        "event=task-complete",
+        "webhook_env=DISCORD_WEBHOOK_AI_STATUS_TEST",
+        f"secret_file={Path.home()}/.config/secrets/discord_test_webhook.env",
     ]
 
 


### PR DESCRIPTION
## Summary
- resolve logical notification routes in scripts/notify before adapter dispatch
- let the shared discord adapter consume the route-selected webhook env and secret path
- cover smoke-test and discord-test alias routing with focused wrapper tests

## Testing
- pytest tests/test_notify_wrapper.py tests/test_notify_discord_adapter.py tests/test_codex_notify.py

Closes #338