### PR TITLE
docs(orchestration): define worker registry coordination boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Start here if you want the current source of truth for specific areas:
 | [docs/data-directory.md](./docs/data-directory.md) | Data directory rules |
 | [docs/daily-input-ux-mvp.md](./docs/daily-input-ux-mvp.md) | Heatmap-first daily input direction |
 | [docs/worker-domain.md](./docs/worker-domain.md) | AI worker status domain |
+| [docs/worker-registry-coordination.md](./docs/worker-registry-coordination.md) | Registry と GitHub の orchestration 境界 |
 | [docs/infra/notify-wrapper.md](./docs/infra/notify-wrapper.md) | Notification wrapper and channel behavior |
 | [docs/domain-extension-policy.md](./docs/domain-extension-policy.md) | Rules for adding new domains |
 

--- a/docs/worker-domain.md
+++ b/docs/worker-domain.md
@@ -2,6 +2,7 @@
 
 > 関連 Issue: #324
 > 関連ポリシー: [`docs/domain-extension-policy.md`](./domain-extension-policy.md)
+> 関連 coordination 境界: [`docs/worker-registry-coordination.md`](./worker-registry-coordination.md)
 
 ## 目的
 
@@ -21,6 +22,7 @@
   - 通知契約
   - 人間向け評価やスコア
   - TUI / アニメーション表現
+  - claim / handoff / maintainer override の authoritative record
 
 ## 既存 domain と重複しない理由
 
@@ -71,6 +73,8 @@ worker board では `worker_id` / `terminal_id` / `status` を持つ定型イベ
 - `status`
 
 `current_issue` は任意。
+これは worker が現在扱っている issue のヒントであり、
+issue ownership や claim の成立を表すものではない。
 
 `last_update` のような mutable field は持たず、
 最新時刻はイベントの `ts` から復元する。

--- a/docs/worker-registry-coordination.md
+++ b/docs/worker-registry-coordination.md
@@ -1,0 +1,155 @@
+# worker registry coordination boundary
+
+> 関連 Issue: #376
+> 関連 Issue: #324, #375, #373, #374, #378, #379
+> 関連 docs: [`docs/worker-domain.md`](./worker-domain.md), [`docs/AI_WORKFLOW.md`](./AI_WORKFLOW.md)
+
+## 目的
+
+既存の `events.db` / `worker` domain / `worker-status-set` / dashboard を、
+AI worker orchestration における **registry coordination layer** として
+どう位置づけるかを定義する。
+
+この文書は「どこが canonical source か」と
+「registry が持ってよい責務 / 持たない責務」を固定する。
+
+## 結論
+
+- registry は **worker runtime の観測 + 軽量 coordination 補助** を担う
+- registry は **global ownership の決定者** にはしない
+- `worker` domain の `current_issue` は **現在扱っている issue のヒント** であり、claim そのものではない
+- claim / handoff / maintainer override の正本は、worker 全員が共有できる GitHub 側 metadata に置く
+
+この方針により、既存 worker board の観測用途を保ちながら、
+claim protocol と handoff flow が後から追加されても
+責務衝突を起こしにくくする。
+
+## registry の役割
+
+registry が担うもの:
+
+- worker ごとの最新 runtime 状態の観測
+- terminal ごとの liveness と `last_update` の復元
+- dashboard / `ai-board` が読む軽量な最新状態ビュー
+- GitHub 側 canonical state を補助的に表示するための projection 先
+
+registry が担わないもの:
+
+- issue ownership の裁定
+- claim / release / handoff の authoritative record
+- maintainer override の最終記録
+- GitHub Project の status / priority の正本管理
+
+言い換えると、registry は **coordination の補助面** には入るが、
+**排他制御や ownership の最終判定** までは担わない。
+
+## canonical source matrix
+
+| state | canonical source | registry の扱い | 理由 |
+|---|---|---|---|
+| worker status | `events.db` の `worker` domain event | 正本として保持 | `worker_id` / `terminal_id` / `status` / `last_update` は runtime ローカルで最も自然に生成されるため |
+| claim state | GitHub Issue 側の claim record（#375 で定義） | 任意の mirror / cache は可、ただし正本にしない | claim は複数 runtime と maintainer が共有して読む必要があり、GitHub 側の可視性が高い |
+| handoff state | GitHub Issue 側の handoff record（#375 で定義） | worker status として周辺状態を映してよいが、正本にしない | handoff は worker 間の引き継ぎ判断そのものなので、共有可視性を優先する |
+| project status / priority | GitHub Project metadata | 持たない | orchestration policy では参照対象だが、registry に複製すると責務が二重化する |
+
+## component boundary
+
+### `events.db`
+
+- append-only の runtime registry storage
+- `worker` domain の最新状態を復元する基盤
+- claim / handoff の正本 storage には昇格させない
+
+### `worker` domain
+
+- worker 観測イベント専用 domain
+- 記録対象は `worker_id` / `worker_name` / `terminal_id` / `status` / `current_issue` のような
+  runtime 状態に限定する
+- GitHub Issue の ownership や override 決定は直接表現しない
+
+### `worker-status-set`
+
+- registry へ worker 状態を append する writer
+- 書いてよいのは worker の runtime 状態のみ
+- claim の取得 / 解放 / handoff 完了をこの command 単体で成立させない
+
+### dashboard / `ai-board`
+
+- registry を読んで最新 worker 状態を表示する reader
+- 将来 GitHub 側 claim 情報を併記してもよいが、
+  ownership 判定ロジックは dashboard に持たせない
+- registry と GitHub 側に不一致がある場合は、
+  GitHub claim/handoff を優先し、dashboard 側は stale / unknown として扱う
+
+## GitHub metadata との責務分担
+
+GitHub 側に置く情報:
+
+- 誰が issue を claim したか
+- claim が release / expire / override されたか
+- どの worker へ handoff したいか、handoff が成立したか
+- maintainer が介入した判断ログ
+
+registry 側に置く情報:
+
+- どの worker / terminal が今どの状態か
+- いつ最後に更新されたか
+- 今どの issue を扱っているつもりかという runtime ヒント
+
+境界ルール:
+
+- GitHub 側 metadata が collaboration truth
+- registry 側 metadata が runtime observability truth
+- `current_issue=#376` の registry 記録だけでは、`#376` を claim したことにはならない
+
+## playbook / policy / protocol との接続点
+
+### PLAYBOOK（#373）
+
+- 着手条件、再開条件、handoff 完了条件は GitHub 側 claim/handoff record を参照する
+- registry は「その worker が最近生きているか」「reviewing / waiting か」を補助的に示す
+
+### WORKER_POLICY（#374）
+
+- dispatch policy は task-class と runtime 適性を定める
+- 実際に誰が占有中かの確認は GitHub 側 claim state を見る
+- registry の freshness は dispatch の参考情報には使えるが、裁定根拠にはしない
+
+### Claim Protocol（#375）
+
+- claim / release / expire / handoff の状態遷移と正規 record 形式を定義する
+- registry はその protocol を補助的に可視化してよいが、正本の置換をしない
+
+## divergence rule
+
+GitHub 側と registry 側で状態がずれた場合は、次の順で扱う。
+
+1. claim / handoff / override は GitHub 側を正として読む
+2. worker の liveness / last seen は registry 側を正として読む
+3. dashboard 表示で両者を混同しない
+4. 一方を見て他方を上書きする自動同期は baseline では行わない
+
+このルールにより、二重書きの見かけ上の不整合が起きても
+「どちらを信じるべきか」が固定される。
+
+## follow-up items
+
+- #375: claim / handoff record の具体形式と stale claim ルールを定義する
+- #373: playbook 上の着手 / 中断 / handoff / 再開条件を、この境界に合わせて記述する
+- #374: dispatch policy 上の確認順序を `GitHub claim -> registry observability` に揃える
+- #379: dashboard や `worker-status-set` の baseline 実装を、この責務分担に沿って更新する
+- #378: claim baseline 実装では GitHub 側 canonical path を使い、registry mirror は必要最小限に留める
+
+## 非スコープ
+
+- GitHub と registry の完全双方向同期
+- `worker` domain schema の直ちの拡張
+- scheduler や自動 claim 再割当
+- dashboard UI の大規模改修
+
+## リスク
+
+- GitHub 側 write path が増えると manual operation が少し重くなる
+- registry を正本にしないため、dashboard 単体では ownership 完了判定ができない
+
+ただし、初期段階では「見えること」より「二重正本にしないこと」を優先する。


### PR DESCRIPTION
## 関連Issue
- Closes #376

## 概要
- 変更内容:
  - `docs/worker-registry-coordination.md` を追加し、worker status / claim / handoff の canonical source を定義
  - `docs/worker-domain.md` に claim/handoff の境界と `current_issue` 非 authoritative を追記
  - `README.md` から新設計文書へ辿れる導線を追加
- 理由:
  - registry と GitHub metadata の二重正本化を避けるため
  - #375 / #373 / #374 / #379 / #378 が参照できる境界を先に固定するため

## 検証
- python: `python -m ruff check .` 成功
- ruff: `python -m ruff format --check .` 成功
- pytest: `pytest` 成功（364 passed, 12 skipped）
- `ruff check .`: success
- `pytest`: 364 passed, 12 skipped

## レビューノート
- スコープ: docs のみ。コード挙動変更なし
- 挙動変更: worker registry は observability truth、claim/handoff は GitHub truth として整理
- リスク: #375 で claim/handoff record 形式を別途確定する必要がある
- 緩和策: 本PR内で follow-up と divergence rule を明記

## 最小修正
- 適用内容: なし
- 理由: 検証で直接確認できた失敗がなかったため

## 次のIssue
- #375 Worker Claim Protocol の最小仕様を定義する
- #373 PLAYBOOK.md に AI worker 標準作業フローを定義する
- #374 WORKER_POLICY.md に multi-runtime dispatch policy を定義する
- #379 Worker Registry Coordination baseline を実装する
