### PR TITLE
routing: Discord webhook destination を env / purpose で分離する

### DIFF
--- a/docs/infra/discord-webhook-channel-contract.md
+++ b/docs/infra/discord-webhook-channel-contract.md
@@ -33,7 +33,10 @@ Discord 送信実装そのものは対象外とする。
 
 | env var | meaning |
 |---|---|
-| `DISCORD_WEBHOOK_AI_STATUS` | Discord incoming webhook URL |
+| `DISCORD_WEBHOOK_AI_STATUS` | default Discord incoming webhook URL for the normal `discord` route |
+| `DISCORD_WEBHOOK_AI_STATUS_DEV` | optional Discord incoming webhook URL when the wrapper selects `NOTIFY_ENV=dev` |
+| `DISCORD_WEBHOOK_AI_STATUS_PROD` | optional Discord incoming webhook URL when the wrapper selects `NOTIFY_ENV=prod` |
+| `DISCORD_WEBHOOK_AI_STATUS_TEST` | Discord incoming webhook URL for the `discord-test` route |
 
 ### Optional
 
@@ -44,7 +47,8 @@ Discord 送信実装そのものは対象外とする。
 
 ### Rules
 
-- `DISCORD_WEBHOOK_AI_STATUS` が未設定または空文字なら adapter は送信を試みない
+- wrapper は routing 結果に応じて `NOTIFY_DISCORD_WEBHOOK_ENV_NAME` を渡してよい
+- adapter は route-selected webhook env var が未設定または空文字なら送信を試みない
 - channel 選択は既存どおり `NOTIFY_CHANNEL=discord` または `notify --channel discord` を使う
 - Discord 固有の設定は adapter 内に閉じ込め、`scripts/notify` の共通引数へ追加しない
 
@@ -119,7 +123,7 @@ Rules:
 
 ### Missing webhook configuration
 
-- `DISCORD_WEBHOOK_AI_STATUS` が未設定または空文字なら stderr に原因を書く
+- route-selected webhook env var が未設定または空文字なら stderr に原因を書く
 - exit code は `2` とする
 - これは usage / configuration error として扱い、HTTP request は送らない
 

--- a/docs/infra/notify-wrapper.md
+++ b/docs/infra/notify-wrapper.md
@@ -40,14 +40,28 @@ The adapter sends plain-text webhook payloads only. Missing webhook
 configuration exits with code `2`; HTTP or transport failures exit with code
 `1`.
 
+If you need normal Discord delivery split by environment, set
+`NOTIFY_ENV=dev` or `NOTIFY_ENV=prod` before calling `notify`. In that case
+the logical `discord` route switches to env-specific webhook names:
+
+| `NOTIFY_ENV` | webhook env var | secret-file fallback |
+|---|---|---|
+| unset | `DISCORD_WEBHOOK_AI_STATUS` | `~/.config/secrets/discord_webhook.env` |
+| `dev` | `DISCORD_WEBHOOK_AI_STATUS_DEV` | `~/.config/secrets/discord_webhook_dev.env` |
+| `prod` | `DISCORD_WEBHOOK_AI_STATUS_PROD` | `~/.config/secrets/discord_webhook_prod.env` |
+
+This split applies only to the normal `discord` route. Purpose-aware routing
+still takes precedence, so `--kind smoke_test` continues to land on
+`discord-test` and does not reuse the `dev` / `prod` webhook selection.
+
 ### Secret management
 
 Webhook secret は次の優先順位で解決される。
 
-1. `DISCORD_WEBHOOK_AI_STATUS` environment variable
-2. `~/.config/secrets/discord_webhook.env` fallback
+1. route-selected environment variable
+2. route-selected secret-file fallback
 
-adapter は `DISCORD_WEBHOOK_AI_STATUS` が未設定のときだけ fallback file を読む。
+adapter は route-selected webhook env var が未設定のときだけ fallback file を読む。
 そのため、一時的な差し替えや検証では process env を優先できる。
 
 Example:
@@ -60,6 +74,14 @@ echo 'export DISCORD_WEBHOOK_AI_STATUS="https://discord.com/api/webhooks/..."' \
   > ~/.config/secrets/discord_webhook.env
 
 chmod 600 ~/.config/secrets/discord_webhook.env
+```
+
+Environment-specific example:
+
+```bash
+export NOTIFY_ENV=dev
+export DISCORD_WEBHOOK_AI_STATUS_DEV="https://discord.com/api/webhooks/..."
+notify --event task_completed --title "issue #285" --source codex-tui "routed to dev"
 ```
 
 ## Discord smoke-test channel
@@ -393,8 +415,10 @@ Current mapping for Codex task completion:
 
 The bridge keeps `scripts/notify` as the single notification entrypoint, so
 channel selection for day-to-day delivery still comes from `NOTIFY_CHANNEL` /
-`NOTIFY_CHANNEL_DIR`. `--smoke-test` uses kind routing and lands on
-`discord-test`.
+`NOTIFY_CHANNEL_DIR`. If `NOTIFY_ENV=dev|prod` is set and the route stays on
+logical `discord`, the wrapper selects `DISCORD_WEBHOOK_AI_STATUS_DEV` or
+`DISCORD_WEBHOOK_AI_STATUS_PROD`. `--smoke-test` still uses kind routing and
+lands on `discord-test`.
 
 ### Dry-run verification
 

--- a/scripts/notify
+++ b/scripts/notify
@@ -52,8 +52,24 @@ resolve_notification_route() {
 
   case "$logical_channel" in
     discord)
-      DISCORD_WEBHOOK_ENV_NAME="DISCORD_WEBHOOK_AI_STATUS"
-      DISCORD_WEBHOOK_SECRET_FILE="$HOME/.config/secrets/discord_webhook.env"
+      case "${NOTIFY_ENV:-}" in
+        "")
+          DISCORD_WEBHOOK_ENV_NAME="DISCORD_WEBHOOK_AI_STATUS"
+          DISCORD_WEBHOOK_SECRET_FILE="$HOME/.config/secrets/discord_webhook.env"
+          ;;
+        dev)
+          DISCORD_WEBHOOK_ENV_NAME="DISCORD_WEBHOOK_AI_STATUS_DEV"
+          DISCORD_WEBHOOK_SECRET_FILE="$HOME/.config/secrets/discord_webhook_dev.env"
+          ;;
+        prod)
+          DISCORD_WEBHOOK_ENV_NAME="DISCORD_WEBHOOK_AI_STATUS_PROD"
+          DISCORD_WEBHOOK_SECRET_FILE="$HOME/.config/secrets/discord_webhook_prod.env"
+          ;;
+        *)
+          echo "notify: unsupported NOTIFY_ENV: ${NOTIFY_ENV}" >&2
+          exit 2
+          ;;
+      esac
       ;;
     discord-test)
       ADAPTER_CHANNEL="discord"

--- a/tests/test_notify_discord_adapter.py
+++ b/tests/test_notify_discord_adapter.py
@@ -57,6 +57,13 @@ def _write_secret_file(home: Path, content: str) -> Path:
     return secret_file
 
 
+def _write_prod_secret_file(home: Path, content: str) -> Path:
+    secret_file = home / ".config" / "secrets" / "discord_webhook_prod.env"
+    secret_file.parent.mkdir(parents=True, exist_ok=True)
+    secret_file.write_text(content, encoding="utf-8")
+    return secret_file
+
+
 def _write_test_secret_file(home: Path, content: str) -> Path:
     secret_file = home / ".config" / "secrets" / "discord_test_webhook.env"
     secret_file.parent.mkdir(parents=True, exist_ok=True)
@@ -208,6 +215,73 @@ def test_notify_discord_channel_errors_for_transport_failure(tmp_path: Path) -> 
     assert "webhook POST failed" in result.stderr
 
 
+def test_notify_discord_channel_uses_dev_webhook_when_notify_env_is_dev(tmp_path: Path) -> None:
+    _, args_file = _write_fake_curl(tmp_path)
+    env = {
+        **_fake_curl_env(tmp_path, args_file),
+        "NOTIFY_ENV": "dev",
+        "DISCORD_WEBHOOK_AI_STATUS_DEV": "https://discord.example/dev-webhook",
+    }
+
+    result = _run_notify("--channel", "discord", "hello", env=env)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    args, payload = _load_payload(args_file)
+    assert args[-1] == "https://discord.example/dev-webhook"
+    assert payload == {
+        "content": "hello\n[`generic`]",
+    }
+
+
+def test_notify_discord_channel_uses_prod_secret_file_when_notify_env_is_prod(
+    tmp_path: Path,
+) -> None:
+    _, args_file = _write_fake_curl(tmp_path)
+    home = tmp_path / "home"
+    _write_prod_secret_file(
+        home,
+        'export DISCORD_WEBHOOK_AI_STATUS_PROD="https://discord.example/prod-from-file"\n',
+    )
+
+    result = _run_notify(
+        "--channel",
+        "discord",
+        "hello",
+        env={
+            **_fake_curl_env(tmp_path, args_file),
+            "HOME": str(home),
+            "NOTIFY_ENV": "prod",
+        },
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    args, payload = _load_payload(args_file)
+    assert args[-1] == "https://discord.example/prod-from-file"
+    assert payload == {
+        "content": "hello\n[`generic`]",
+    }
+
+
+def test_notify_discord_channel_errors_for_unsupported_notify_env(tmp_path: Path) -> None:
+    _, args_file = _write_fake_curl(tmp_path)
+    env = {
+        **_fake_curl_env(tmp_path, args_file),
+        "NOTIFY_ENV": "staging",
+        "DISCORD_WEBHOOK_AI_STATUS": "https://discord.example/webhook",
+    }
+
+    result = _run_notify("--channel", "discord", "hello", env=env)
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "unsupported NOTIFY_ENV: staging" in result.stderr
+    assert not args_file.exists()
+
+
 def test_notify_discord_test_channel_posts_expected_payload(tmp_path: Path) -> None:
     _, args_file = _write_fake_curl(tmp_path)
     env = {
@@ -307,6 +381,28 @@ def test_notify_discord_test_channel_errors_without_env_or_secret_file(tmp_path:
         env={
             **_fake_curl_env(tmp_path, args_file),
             "HOME": str(home),
+        },
+    )
+
+    assert result.returncode == 2
+    assert "DISCORD_WEBHOOK_AI_STATUS_TEST is required" in result.stderr
+    assert not args_file.exists()
+
+
+def test_notify_smoke_test_kind_ignores_notify_env_split(tmp_path: Path) -> None:
+    _, args_file = _write_fake_curl(tmp_path)
+    home = tmp_path / "home"
+
+    result = _run_notify(
+        "--kind",
+        "smoke_test",
+        "hello",
+        env={
+            **_fake_curl_env(tmp_path, args_file),
+            "HOME": str(home),
+            "NOTIFY_ENV": "dev",
+            "DISCORD_WEBHOOK_AI_STATUS_TEST": "",
+            "DISCORD_WEBHOOK_AI_STATUS_DEV": "https://discord.example/dev-webhook",
         },
     )
 


### PR DESCRIPTION
Refs #285

## Summary
- `scripts/notify` の `discord` route に `NOTIFY_ENV=dev|prod` の分岐を追加
- `smoke_test` は従来どおり purpose-aware routing を優先し、`discord-test` を使い続けるように維持
- env / purpose routing の挙動をテストとドキュメントに反映

## Test
- `ruff check tests/test_notify_discord_adapter.py tests/test_codex_notify.py scripts/codex_notify.py`
- `bash -n scripts/notify scripts/notify.d/discord scripts/notify.d/discord-test scripts/notify.d/_discord_webhook.sh`
- `pytest tests/test_notify_discord_adapter.py tests/test_codex_notify.py`

## Notes
- `NOTIFY_ENV` 未設定時は既存の `DISCORD_WEBHOOK_AI_STATUS` を使う
- `NOTIFY_ENV` が `dev` / `prod` 以外なら usage error として終了する
