### PR TITLE
docs(notify): clarify env and purpose routing precedence

### DIFF
--- a/docs/infra/discord-webhook-channel-contract.md
+++ b/docs/infra/discord-webhook-channel-contract.md
@@ -51,6 +51,9 @@ Discord 送信実装そのものは対象外とする。
 - adapter は route-selected webhook env var が未設定または空文字なら送信を試みない
 - channel 選択は既存どおり `NOTIFY_CHANNEL=discord` または `notify --channel discord` を使う
 - Discord 固有の設定は adapter 内に閉じ込め、`scripts/notify` の共通引数へ追加しない
+- purpose-aware routing は wrapper 側で先に解決し、`smoke_test` は `NOTIFY_ENV` より優先して `discord-test` へ向かう
+- `NOTIFY_ENV=dev|prod` の分岐は logical route が `discord` のときだけ適用する
+- `discord-test` route は `DISCORD_WEBHOOK_AI_STATUS_TEST` だけを見る fail-closed 動作とし、`DISCORD_WEBHOOK_AI_STATUS*` への fallback をしない
 
 ## 3. Input contract from `scripts/notify`
 

--- a/docs/infra/notify-wrapper.md
+++ b/docs/infra/notify-wrapper.md
@@ -54,6 +54,28 @@ This split applies only to the normal `discord` route. Purpose-aware routing
 still takes precedence, so `--kind smoke_test` continues to land on
 `discord-test` and does not reuse the `dev` / `prod` webhook selection.
 
+### Routing precedence
+
+`scripts/notify` resolves Discord delivery in three stages:
+
+1. decide the logical route from `--kind` when a purpose-specific route exists
+2. fall back to the requested logical channel (`discord` / `discord-test`)
+3. if the logical route is still `discord`, apply optional `NOTIFY_ENV=dev|prod`
+   webhook selection
+
+Current matrix:
+
+| caller input | logical route | webhook selection | notes |
+|---|---|---|---|
+| `--channel discord` and `NOTIFY_ENV` unset | `discord` | `DISCORD_WEBHOOK_AI_STATUS` | default normal delivery |
+| `--channel discord` and `NOTIFY_ENV=dev` | `discord` | `DISCORD_WEBHOOK_AI_STATUS_DEV` | env split for normal delivery |
+| `--channel discord` and `NOTIFY_ENV=prod` | `discord` | `DISCORD_WEBHOOK_AI_STATUS_PROD` | env split for normal delivery |
+| `--channel discord-test` with any `NOTIFY_ENV` | `discord-test` | `DISCORD_WEBHOOK_AI_STATUS_TEST` | purpose route ignores env split |
+| `--kind smoke_test` with any `NOTIFY_ENV` | `discord-test` | `DISCORD_WEBHOOK_AI_STATUS_TEST` | kind routing wins over env split |
+
+This keeps `dev/prod` split as one branch of the normal Discord route, while
+test-oriented delivery remains purpose-aware and fail-closed.
+
 ### Secret management
 
 Webhook secret は次の優先順位で解決される。

--- a/tests/test_notify_wrapper.py
+++ b/tests/test_notify_wrapper.py
@@ -157,7 +157,10 @@ def test_notify_channel_alias_routes_discord_test_through_discord_adapter(tmp_pa
         "--event",
         "task-complete",
         "smoke done",
-        env={"NOTIFY_CHANNEL_DIR": str(tmp_path)},
+        env={
+            "NOTIFY_CHANNEL_DIR": str(tmp_path),
+            "NOTIFY_ENV": "prod",
+        },
     )
 
     assert result.stdout.splitlines() == [


### PR DESCRIPTION
Closes #285

## Summary
- document routing precedence between purpose-aware routing and NOTIFY_ENV-based webhook selection
- add an explicit routing matrix for discord / discord-test delivery
- keep discord-test fail-closed and lock the behavior with a wrapper test

## Testing
- pytest tests/test_notify_wrapper.py tests/test_notify_discord_adapter.py tests/test_codex_notify.py -q