### PR TITLE
docs: sync external ingest implementation docs

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,6 +1,8 @@
 # Adapters
 
 Adapters translate between external protocols and `personal_mcp.core` functions.
+Current external input surfaces are not all adapters: some integrations are
+implemented as tool-layer CLI entry points instead.
 
 ## Naming convention
 
@@ -17,6 +19,23 @@ or similar. Keep adapters thin — no business logic, only protocol translation.
 |---------|------|--------|
 | MCP (base) | `adapters/mcp_server.py` | Placeholder |
 | HTTP (mobile log form) | `adapters/http_server.py` | MVP (Issue #145) |
+
+These are the only runtime adapters currently shipped.
+
+## Current external input surfaces
+
+| Surface | Entry point | Implementation | Status |
+|---|---|---|---|
+| MCP context | internal | `adapters/mcp_server.py` | Placeholder |
+| HTTP mobile log form | `web-serve` | `adapters/http_server.py` | MVP |
+| GitHub manual sync MVP | `github-sync` | `tools/github_sync.py` | Implemented |
+| GitHub richer ingest | `github-ingest` | `tools/github_ingest.py` | Implemented |
+| Local client log watcher | `poe2-watch` | `tools/poe2_client_watcher.py` | Implemented |
+
+GitHub ingest is intentionally listed here as an external input surface rather
+than an adapter. In the current runtime, GitHub is handled by tool-layer CLI
+commands that fetch and normalize events before writing through the storage
+boundary.
 
 ## Adding a new adapter
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ personal-mcp-core
 | Adapter | `adapters/mcp_server.py` | Translates MCP protocol to internal calls |
 | Adapter | `adapters/http_server.py` | HTTP server for mobile log form (`web-serve`) |
 | Tools | `tools/*.py` | Domain logic: event, daily_summary, github_*, worker, poe2 |
-| Storage | `storage/events_store.py` | Storage boundary: read/write events (DB + JSONL dual-write) |
+| Storage | `storage/events_store.py` | Storage boundary: runtime read/write against `events.db`, plus explicit recovery rebuild commands for `events.jsonl` |
 | Core | `core/guide.py` | Loads and caches the AI guide text |
 | Data | `AI_GUIDE.md` | The guide content itself |
 
@@ -66,6 +66,21 @@ Persistent storage (daily logs, habit data, game state) belongs in
 Data-dir resolution is a CLI concern in `src/personal_mcp/server.py`.
 Resolution order is `--data-dir`, `PERSONAL_MCP_DATA_DIR`, then the XDG default.
 Tool-layer functions receive a resolved `data_dir` and do not interpret env vars or XDG.
+
+### Current external input surfaces
+
+Current runtime input surfaces are split between adapters and tool-driven ingest.
+
+| Surface | Entry point | Layer | Notes |
+|---|---|---|---|
+| MCP context | `adapters/mcp_server.py` | adapter | MCP-facing interface |
+| Mobile log form | `web-serve` -> `adapters/http_server.py` | adapter | HTTP input surface for event capture |
+| GitHub manual sync MVP | `github-sync` -> `tools/github_sync.py` | tool | Reads `/users/{username}/events` first page and writes `eng` events |
+| GitHub richer ingest | `github-ingest` -> `tools/github_ingest.py` | tool | Same endpoint, richer `data.*` payload per `docs/eng-ingest-impl.md` |
+| Local client log watch | `poe2-watch` -> `tools/poe2_client_watcher.py` | tool | Tails a local file and appends events on area transitions |
+
+GitHub integration is currently implemented as tool-layer CLI ingest, not as an
+adapter module. The only runtime adapters shipped today are MCP and HTTP.
 
 ## Skills layer
 
@@ -123,9 +138,9 @@ Tradeoff: manual sync is required. Accepted because the file changes rarely.
 
 `server.py` exposes a multi-subcommand CLI (via `argparse`) registered as the
 `personal-mcp` console script in `pyproject.toml`. Key subcommands include
-`event-add`, `event-today`, `event-list`, `web-serve`, `summary-generate`,
-`github-ingest`, and storage-maintenance commands (`storage-db-to-jsonl`,
-`storage-jsonl-to-db`).
+`event-add`, `event-today`, `event-list`, `web-serve`, `poe2-watch`,
+`github-sync`, `github-ingest`, `summary-generate`, and storage-maintenance
+commands (`storage-db-to-jsonl`, `storage-jsonl-to-db`).
 
 Running `python -m personal_mcp.server` without a subcommand exits with a usage
 error. Always supply a subcommand (or `--help`) when invoking it directly.


### PR DESCRIPTION
## 関連Issue
- Refs #248

## 概要
- 変更内容: 外部データ取り込みの現状に合わせて architecture / adapters ドキュメントを同期
- 理由: GitHub 取り込みが tool-layer CLI 実装であることと、runtime storage の現在地を docs から誤読しにくくするため

## 検証
- python: `Python 3.10.12`
- ruff: `ruff 0.15.5`
- pytest: `pytest 9.0.2`
- `ruff check .`: pass
- `pytest`: pass (`363 passed, 12 skipped`)

## レビューノート
- スコープ: `docs/architecture.md`, `docs/adapters.md` のみ
- 挙動変更: なし（docs sync only）
- リスク: 関連 docs に同種の stale 記述が残っている可能性
- 緩和策: 実装参照を増やし、GitHub 取り込みと adapter の境界を明記

## 最小修正
- 適用内容: storage 境界の説明を `events.db` 正本 + recovery command に修正し、GitHub / PoE2 の外部入力面を明文化
- 理由: 調査結果と runtime 実装を docs に合わせるため
