### PR TITLE
feat: add notification policy defaults

### DIFF
--- a/docs/ai-notification-contract-v1.md
+++ b/docs/ai-notification-contract-v1.md
@@ -104,6 +104,8 @@ channel adapter が現時点で直接受け取れる field とは一致しない
 - `NOTIFY_TITLE`
 - `NOTIFY_EVENT`
 - `NOTIFY_SOURCE`
+- `NOTIFY_SEVERITY`
+- `NOTIFY_VERBOSITY`
 - stdin に流す message body
 
 このため Discord webhook の最小実装（#238）は、上記 projection だけで送れる範囲に留める。
@@ -116,6 +118,12 @@ optional metadata 候補の扱いは次の通り整理する。
 | `run_url` | optional。確認用 URL | 送らない | wrapper が field を adapter へ渡していない。必要なら wrapper 拡張で扱う |
 | `next_action` | optional。人間に求める次の行動 | 送らない | `needs_input` / `task_failed` では有用だが、現状は wrapper 拡張なしに adapter へ渡せない |
 | `metadata` | optional。channel 非依存の補助情報 | 送らない | key の正規化と adapter への受け渡し方式を別途決める必要がある |
+
+補足:
+
+- `NOTIFY_SEVERITY` / `NOTIFY_VERBOSITY` は wrapper が kind / event から解決する
+  advisory policy metadata であり、Section 3 の上位入力 JSON に必須追加するものではない
+- 現時点では adapter が rendering や suppression に必ず使う前提は置かない
 
 ### Rules for #238
 

--- a/docs/infra/discord-webhook-channel-contract.md
+++ b/docs/infra/discord-webhook-channel-contract.md
@@ -62,10 +62,17 @@ Discord adapter は次の入力を受け取る。
 | `NOTIFY_TITLE` | no | 1 行の見出し |
 | `NOTIFY_EVENT` | yes | イベント種別 |
 | `NOTIFY_SOURCE` | no | 通知元ラベル |
+| `NOTIFY_SEVERITY` | no | wrapper が解決した advisory severity |
+| `NOTIFY_VERBOSITY` | no | wrapper が解決した advisory verbosity |
 | stdin | yes | `NOTIFY_MESSAGE` と同じ本文 |
 
 `NOTIFY_MESSAGE` が空になる入力は wrapper 側で弾かれるため、adapter は
 wrapper からの正規化済み入力を前提にしてよい。
+
+`NOTIFY_SEVERITY` / `NOTIFY_VERBOSITY` は policy metadata であり、routing や
+payload 必須項目ではない。v1 の Discord adapter はこれらを rendering に必須利用
+しなくてよいが、将来 policy-aware な channel adapter を作る場合の参照値として
+受け取ってよい。
 
 ## 4. Minimal Discord payload
 
@@ -118,6 +125,7 @@ Rules:
 - `NOTIFY_TITLE` は Discord 上で視認しやすいよう太字 1 行に限定する
 - Markdown 装飾は title の強調以外を前提にしない
 - v1 では AI notification contract の optional fields を Discord 専用 field へ展開しない
+- v1 では `NOTIFY_SEVERITY` / `NOTIFY_VERBOSITY` を provenance 行へ埋め込まない
 
 ## 6. Failure and exit-code policy
 

--- a/docs/infra/notify-wrapper.md
+++ b/docs/infra/notify-wrapper.md
@@ -20,6 +20,33 @@ Discord webhook 向けの最小契約は
 [`docs/infra/discord-webhook-channel-contract.md`](./discord-webhook-channel-contract.md)
 で別途定義する。
 
+## Notification policy defaults
+
+`scripts/notify` は routing とは別に、通知ごとの policy metadata も正規化する。
+現時点で wrapper が adapter へ渡す policy metadata は次の 2 つ。
+
+- `NOTIFY_SEVERITY`: `info` / `warning` / `error`
+- `NOTIFY_VERBOSITY`: `debug` / `normal` / `critical`
+
+この policy は現在の v1 では advisory metadata として扱い、wrapper 自体は
+suppression や threshold 判定までは行わない。まずは通知の意味と routing に加えて
+「人間にどの強度で見せたいか」を adapter 側で参照できる状態を固定する。
+
+Default mapping:
+
+| input | event | severity | verbosity | note |
+|---|---|---|---|---|
+| `--kind ai_task_completed` | `task_completed` | `info` | `normal` | 通常の完了通知 |
+| `--kind ai_task_failed` | `task_failed` | `error` | `critical` | 介入が必要な失敗通知 |
+| `--kind smoke_test` | `task_completed` | `info` | `debug` | test webhook 向けの観測通知 |
+| `--event needs_input` | `needs_input` | `warning` | `critical` | 人間の入力待ち |
+| `--event task_failed` | `task_failed` | `error` | `critical` | kind を通さない失敗通知 |
+| other `--event` values | as passed | `info` | `normal` | 既定値 |
+
+`--kind` を使う場合は、その kind に紐づく policy が event 既定値より優先される。
+たとえば `--kind smoke_test` は event としては `task_completed` だが、policy は
+通常完了通知ではなく `info/debug` として扱う。
+
 ## Discord webhook channel
 
 Set `NOTIFY_CHANNEL=discord` or pass `--channel discord`, then provide a

--- a/scripts/notify
+++ b/scripts/notify
@@ -8,6 +8,8 @@ KIND=""
 TITLE="${NOTIFY_TITLE:-}"
 EVENT="${NOTIFY_EVENT:-generic}"
 SOURCE="${NOTIFY_SOURCE:-}"
+SEVERITY="${NOTIFY_SEVERITY:-}"
+VERBOSITY="${NOTIFY_VERBOSITY:-}"
 READ_STDIN="0"
 CHANNEL_ARG_SET="0"
 EVENT_ARG_SET="0"
@@ -39,6 +41,62 @@ notification_kind_route() {
       ;;
     *)
       printf '%s' ""
+      ;;
+  esac
+}
+
+notification_kind_severity() {
+  case "$1" in
+    ai_task_failed)
+      printf '%s' "error"
+      ;;
+    ai_task_completed|smoke_test)
+      printf '%s' "info"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+notification_kind_verbosity() {
+  case "$1" in
+    smoke_test)
+      printf '%s' "debug"
+      ;;
+    ai_task_failed)
+      printf '%s' "critical"
+      ;;
+    ai_task_completed)
+      printf '%s' "normal"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+notification_event_severity() {
+  case "$1" in
+    task_failed)
+      printf '%s' "error"
+      ;;
+    needs_input)
+      printf '%s' "warning"
+      ;;
+    *)
+      printf '%s' "info"
+      ;;
+  esac
+}
+
+notification_event_verbosity() {
+  case "$1" in
+    task_failed|needs_input)
+      printf '%s' "critical"
+      ;;
+    *)
+      printf '%s' "normal"
       ;;
   esac
 }
@@ -151,10 +209,28 @@ if [[ -n "$KIND" ]]; then
     exit 2
   fi
 
+  if ! SEVERITY="$(notification_kind_severity "$KIND")"; then
+    echo "notify: unknown notification severity policy for kind: $KIND" >&2
+    exit 2
+  fi
+
+  if ! VERBOSITY="$(notification_kind_verbosity "$KIND")"; then
+    echo "notify: unknown notification verbosity policy for kind: $KIND" >&2
+    exit 2
+  fi
+
   resolved_route="$(notification_kind_route "$KIND")"
   if [[ -n "$resolved_route" ]]; then
     CHANNEL="$resolved_route"
   fi
+fi
+
+if [[ -z "$SEVERITY" ]]; then
+  SEVERITY="$(notification_event_severity "$EVENT")"
+fi
+
+if [[ -z "$VERBOSITY" ]]; then
+  VERBOSITY="$(notification_event_verbosity "$EVENT")"
 fi
 
 if [[ "$READ_STDIN" == "1" ]]; then
@@ -195,6 +271,8 @@ export NOTIFY_MESSAGE="$MESSAGE"
 export NOTIFY_TITLE="$TITLE"
 export NOTIFY_EVENT="$EVENT"
 export NOTIFY_SOURCE="$SOURCE"
+export NOTIFY_SEVERITY="$SEVERITY"
+export NOTIFY_VERBOSITY="$VERBOSITY"
 if [[ -n "$DISCORD_WEBHOOK_ENV_NAME" ]]; then
   export NOTIFY_DISCORD_WEBHOOK_ENV_NAME="$DISCORD_WEBHOOK_ENV_NAME"
   export NOTIFY_DISCORD_WEBHOOK_SECRET_FILE="$DISCORD_WEBHOOK_SECRET_FILE"

--- a/tests/test_notify_wrapper.py
+++ b/tests/test_notify_wrapper.py
@@ -61,6 +61,34 @@ def test_notify_resolves_known_kind_to_event() -> None:
     assert result.stderr == ""
 
 
+def test_notify_exposes_default_event_policy_to_adapters(tmp_path: Path) -> None:
+    adapter = tmp_path / "capture"
+    adapter.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n"
+        "printf 'severity=%s\\n' \"$NOTIFY_SEVERITY\"\n"
+        "printf 'verbosity=%s\\n' \"$NOTIFY_VERBOSITY\"\n",
+        encoding="utf-8",
+    )
+    adapter.chmod(adapter.stat().st_mode | stat.S_IXUSR)
+
+    result = _run_notify(
+        "--channel",
+        "capture",
+        "--event",
+        "needs_input",
+        "Need approval",
+        env={"NOTIFY_CHANNEL_DIR": str(tmp_path)},
+    )
+
+    assert result.stdout.splitlines() == [
+        "event=needs_input",
+        "severity=warning",
+        "verbosity=critical",
+    ]
+
+
 def test_notify_dispatches_to_custom_adapter_directory(tmp_path: Path) -> None:
     adapter = tmp_path / "capture"
     adapter.write_text(
@@ -71,6 +99,8 @@ def test_notify_dispatches_to_custom_adapter_directory(tmp_path: Path) -> None:
         "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n"
         "printf 'title=%s\\n' \"$NOTIFY_TITLE\"\n"
         "printf 'source=%s\\n' \"$NOTIFY_SOURCE\"\n"
+        "printf 'severity=%s\\n' \"$NOTIFY_SEVERITY\"\n"
+        "printf 'verbosity=%s\\n' \"$NOTIFY_VERBOSITY\"\n"
         "printf 'message=%s\\n' \"$NOTIFY_MESSAGE\"\n"
         "printf 'stdin=%s\\n' \"$stdin_payload\"\n",
         encoding="utf-8",
@@ -95,6 +125,8 @@ def test_notify_dispatches_to_custom_adapter_directory(tmp_path: Path) -> None:
         "event=task-complete",
         "title=CI",
         "source=pytest",
+        "severity=info",
+        "verbosity=normal",
         "message=All green",
         "stdin=All green",
     ]
@@ -114,6 +146,8 @@ def test_notify_kind_can_override_channel(tmp_path: Path) -> None:
         "set -euo pipefail\n"
         "printf 'channel=%s\\n' \"$NOTIFY_CHANNEL_NAME\"\n"
         "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n"
+        "printf 'severity=%s\\n' \"$NOTIFY_SEVERITY\"\n"
+        "printf 'verbosity=%s\\n' \"$NOTIFY_VERBOSITY\"\n"
         "printf 'webhook_env=%s\\n' \"$NOTIFY_DISCORD_WEBHOOK_ENV_NAME\"\n"
         "printf 'secret_file=%s\\n' \"$NOTIFY_DISCORD_WEBHOOK_SECRET_FILE\"\n",
         encoding="utf-8",
@@ -133,6 +167,8 @@ def test_notify_kind_can_override_channel(tmp_path: Path) -> None:
     assert result.stdout.splitlines() == [
         "channel=discord-test",
         "event=task_completed",
+        "severity=info",
+        "verbosity=debug",
         "webhook_env=DISCORD_WEBHOOK_AI_STATUS_TEST",
         f"secret_file={Path.home()}/.config/secrets/discord_test_webhook.env",
     ]
@@ -145,6 +181,8 @@ def test_notify_channel_alias_routes_discord_test_through_discord_adapter(tmp_pa
         "set -euo pipefail\n"
         "printf 'channel=%s\\n' \"$NOTIFY_CHANNEL_NAME\"\n"
         "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n"
+        "printf 'severity=%s\\n' \"$NOTIFY_SEVERITY\"\n"
+        "printf 'verbosity=%s\\n' \"$NOTIFY_VERBOSITY\"\n"
         "printf 'webhook_env=%s\\n' \"$NOTIFY_DISCORD_WEBHOOK_ENV_NAME\"\n"
         "printf 'secret_file=%s\\n' \"$NOTIFY_DISCORD_WEBHOOK_SECRET_FILE\"\n",
         encoding="utf-8",
@@ -163,6 +201,8 @@ def test_notify_channel_alias_routes_discord_test_through_discord_adapter(tmp_pa
     assert result.stdout.splitlines() == [
         "channel=discord-test",
         "event=task-complete",
+        "severity=info",
+        "verbosity=normal",
         "webhook_env=DISCORD_WEBHOOK_AI_STATUS_TEST",
         f"secret_file={Path.home()}/.config/secrets/discord_test_webhook.env",
     ]


### PR DESCRIPTION
Refs #339

## Summary
- add default severity / verbosity policy resolution to `scripts/notify`
- export policy metadata to adapters without changing Discord v1 payload rendering
- document the new wrapper policy defaults and cover them with wrapper tests

## Testing
- ruff check .
- ruff format --check .
- pytest tests/test_notify_wrapper.py tests/test_notify_discord_adapter.py tests/test_codex_notify.py

## Notes
- policy metadata is advisory only in this PR; the wrapper does not add suppression or threshold behavior
- existing smoke-test routing to `discord-test` stays unchanged