### PR TITLE
fix: notification policy defaults を明示する

### DIFF
--- a/docs/ai-notification-contract-v1.md
+++ b/docs/ai-notification-contract-v1.md
@@ -180,6 +180,11 @@ optional metadata 候補の扱いは次の通り整理する。
 | `task_failed` | 失敗対象が分かる | 原因の短い要約 | 強く推奨 |
 | `long_task_finished` | 終了した長時間ジョブが分かる | 所要時間や結果の要約 | 任意 |
 
+現在の `scripts/notify` 既定 policy では、`needs_input` と `task_failed` を
+人間の介入が必要な通知として `warning/critical` または `error/critical` に寄せる。
+`task_completed` と `long_task_finished` は `info/normal` が既定で、`smoke_test` は
+kind policy により `task_completed` へ投影しつつ `info/debug` として扱う。
+
 ## 7. Out of Scope for v1
 
 - channel ごとのタイトル文字数制限や装飾仕様

--- a/docs/infra/notify-wrapper.md
+++ b/docs/infra/notify-wrapper.md
@@ -8,7 +8,7 @@ need to emit a notification without depending on a specific delivery channel.
 ```bash
 PATH="$PWD/scripts:$PATH"
 notify "build finished"
-notify --event input-required --title "Codex" "Need approval"
+notify --event needs_input --title "Codex" "Need approval"
 printf 'multiline message' | notify --stdin
 ```
 
@@ -40,6 +40,7 @@ Default mapping:
 | `--kind ai_task_failed` | `task_failed` | `error` | `critical` | 介入が必要な失敗通知 |
 | `--kind smoke_test` | `task_completed` | `info` | `debug` | test webhook 向けの観測通知 |
 | `--event needs_input` | `needs_input` | `warning` | `critical` | 人間の入力待ち |
+| `--event long_task_finished` | `long_task_finished` | `info` | `normal` | 観測用の終了通知 |
 | `--event task_failed` | `task_failed` | `error` | `critical` | kind を通さない失敗通知 |
 | other `--event` values | as passed | `info` | `normal` | 既定値 |
 

--- a/scripts/notify
+++ b/scripts/notify
@@ -84,6 +84,9 @@ notification_event_severity() {
     needs_input)
       printf '%s' "warning"
       ;;
+    long_task_finished)
+      printf '%s' "info"
+      ;;
     *)
       printf '%s' "info"
       ;;
@@ -94,6 +97,9 @@ notification_event_verbosity() {
   case "$1" in
     task_failed|needs_input)
       printf '%s' "critical"
+      ;;
+    long_task_finished)
+      printf '%s' "normal"
       ;;
     *)
       printf '%s' "normal"

--- a/tests/test_notify_wrapper.py
+++ b/tests/test_notify_wrapper.py
@@ -89,6 +89,34 @@ def test_notify_exposes_default_event_policy_to_adapters(tmp_path: Path) -> None
     ]
 
 
+def test_notify_exposes_long_task_finished_policy_to_adapters(tmp_path: Path) -> None:
+    adapter = tmp_path / "capture"
+    adapter.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n"
+        "printf 'severity=%s\\n' \"$NOTIFY_SEVERITY\"\n"
+        "printf 'verbosity=%s\\n' \"$NOTIFY_VERBOSITY\"\n",
+        encoding="utf-8",
+    )
+    adapter.chmod(adapter.stat().st_mode | stat.S_IXUSR)
+
+    result = _run_notify(
+        "--channel",
+        "capture",
+        "--event",
+        "long_task_finished",
+        "Sync completed",
+        env={"NOTIFY_CHANNEL_DIR": str(tmp_path)},
+    )
+
+    assert result.stdout.splitlines() == [
+        "event=long_task_finished",
+        "severity=info",
+        "verbosity=normal",
+    ]
+
+
 def test_notify_dispatches_to_custom_adapter_directory(tmp_path: Path) -> None:
     adapter = tmp_path / "capture"
     adapter.write_text(
@@ -171,6 +199,32 @@ def test_notify_kind_can_override_channel(tmp_path: Path) -> None:
         "verbosity=debug",
         "webhook_env=DISCORD_WEBHOOK_AI_STATUS_TEST",
         f"secret_file={Path.home()}/.config/secrets/discord_test_webhook.env",
+    ]
+
+
+def test_notify_failed_kind_uses_error_critical_policy(tmp_path: Path) -> None:
+    adapter = tmp_path / "capture"
+    adapter.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf 'event=%s\\n' \"$NOTIFY_EVENT\"\n"
+        "printf 'severity=%s\\n' \"$NOTIFY_SEVERITY\"\n"
+        "printf 'verbosity=%s\\n' \"$NOTIFY_VERBOSITY\"\n",
+        encoding="utf-8",
+    )
+    adapter.chmod(adapter.stat().st_mode | stat.S_IXUSR)
+
+    result = _run_notify(
+        "--kind",
+        "ai_task_failed",
+        "Task failed",
+        env={"NOTIFY_CHANNEL_DIR": str(tmp_path), "NOTIFY_CHANNEL": "capture"},
+    )
+
+    assert result.stdout.splitlines() == [
+        "event=task_failed",
+        "severity=error",
+        "verbosity=critical",
     ]
 
 


### PR DESCRIPTION
## Summary
- `long_task_finished` の policy default を wrapper 実装で明示
- failure / long task の policy default を docs と test で固定
- notify wrapper の usage 例を canonical event 名の `needs_input` に同期

## Testing
- pytest tests/test_notify_wrapper.py
- ruff check tests/test_notify_wrapper.py

Closes #339