### PR TITLE
docs: sync orchestration routing docs

### DIFF
--- a/AI_GUIDE.md
+++ b/AI_GUIDE.md
@@ -11,7 +11,7 @@
 
 ---
 
-> **文書責務**: AI 行動原則・姿勢の**正本**。役割境界の正本は [`docs/AI_ROLE_POLICY.md`](./docs/AI_ROLE_POLICY.md) であり、本文書はその**導線**（再定義しない）。runtime 別 runbook 詳細設計・通知運用は scope 外。
+> **文書責務**: AI 行動原則・姿勢の**正本**。repo-wide entrypoint は [`AGENTS.md`](./AGENTS.md) であり、役割境界の正本は [`docs/AI_ROLE_POLICY.md`](./docs/AI_ROLE_POLICY.md) です。共通進行管理は [`docs/PLAYBOOK.md`](./docs/PLAYBOOK.md)、dispatch policy は [`docs/WORKER_POLICY.md`](./docs/WORKER_POLICY.md) を参照し、本文書はそれらを再定義しません。runtime 別 runbook 詳細設計・通知運用は scope 外です。
 
 ## 基本姿勢（最優先）
 
@@ -129,6 +129,13 @@
 - `worktree: 長期 / 役割ベース`、`branch: 短命 / taskベース` を原則としてください
 - VSCode は worktree ごとに作業机を固定し、待機状態を `main + clean` に保ってください
 - 副作用の可否（実行権限）は運用都合よりも [docs/AI_ROLE_POLICY.md](./docs/AI_ROLE_POLICY.md) を優先してください
+
+## AI orchestration docs
+
+- repo-wide の入口と優先順位は [AGENTS.md](./AGENTS.md) を参照してください
+- Issue 着手から handoff までの共通進行管理は [docs/PLAYBOOK.md](./docs/PLAYBOOK.md) を正本とします
+- runtime 間の dispatch policy は [docs/WORKER_POLICY.md](./docs/WORKER_POLICY.md) を正本とします
+- 本文書は行動原則の正本であり、orchestration の具体フローや dispatch rule は再定義しません
 
 ## Tooling source of truth
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,11 @@ When starting any task, read files in this order before writing or changing anyt
 2. `AI_GUIDE.md` — the owner's values and behavioral expectations for AI
 3. `docs/AI_ROLE_POLICY.md` — authoritative role split for Claude/Codex operations
 4. `docs/AI_WORKFLOW.md` — worktree / branch / VSCode rules when operational context matters
-5. `CLAUDE.md` (this file) — Claude-specific routing and constraints
-6. `docs/architecture.md` — system structure and extension points (if it exists)
-7. Only then: the specific files relevant to the task
+5. `docs/PLAYBOOK.md` — common issue-to-handoff flow when orchestration context matters
+6. `docs/WORKER_POLICY.md` — dispatch policy when runtime selection or reviewer split matters
+7. `CLAUDE.md` (this file) — Claude-specific routing and constraints
+8. `docs/architecture.md` — system structure and extension points (if it exists)
+9. Only then: the specific files relevant to the task
 
 ## AI role split
 
@@ -34,6 +36,12 @@ If this file, `AI_GUIDE.md`, old templates, or historical comments conflict with
 To avoid false stops caused by stale wording, never treat non-authoritative role notes as a blocker by themselves.
 
 `CLAUDE.md` is a routing document for Claude Code after `AGENTS.md` — it provides Claude-specific constraints and routes to authoritative sources. It does not replicate role boundary definitions, runtime runbooks, or notification operations.
+
+When orchestration-specific decisions are needed:
+
+* use [`docs/PLAYBOOK.md`](./docs/PLAYBOOK.md) for phase progression, handoff, pause, and resume rules
+* use [`docs/WORKER_POLICY.md`](./docs/WORKER_POLICY.md) for dispatch policy and implementer/reviewer separation
+* do not redefine those rules in this file
 
 ## Practical guardrails for Claude Code
 

--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -3,7 +3,7 @@
 この文書は [`docs/RUNBOOK_BASELINE.md`](./RUNBOOK_BASELINE.md) で定義した runtime-specific runbook baseline の exemplar（Codex CLI 用）です。
 
 Codex はこの runbook に従って、`review -> ruff -> pytest -> 最小修正 -> 再実行 -> Draft PR` の順で進む。役割境界の正本は [docs/AI_ROLE_POLICY.md](./AI_ROLE_POLICY.md) とし、この文書は実行手順に絞る。
-Repo-wide AI entrypoint は [`AGENTS.md`](../AGENTS.md) です。Codex はまず `AGENTS.md` で read order と precedence を確認し、その後この runbook を使います。
+Repo-wide AI entrypoint は [`AGENTS.md`](../AGENTS.md) です。Codex はまず `AGENTS.md` で read order と precedence を確認し、その後この runbook を使います。Issue 着手から handoff までの共通進行管理は [`docs/PLAYBOOK.md`](./PLAYBOOK.md)、runtime 間の dispatch policy は [`docs/WORKER_POLICY.md`](./WORKER_POLICY.md) を正本とし、この文書では再定義しません。
 
 ## Codex がやること
 


### PR DESCRIPTION
## 概要
- AI_GUIDE.md に orchestration docs の入口導線を追加
- CLAUDE.md の read order と orchestration routing を同期
- CODEX_RUNBOOK.md に PLAYBOOK / WORKER_POLICY の正本参照を追加

Closes #377

## 実行コマンド
- `python` による対象 docs のローカル Markdown リンク検証

## 結果
- `AGENTS.md` / `docs/PLAYBOOK.md` / `docs/WORKER_POLICY.md` と既存導線文書・runbook の参照関係を同期
- 対象 docs のローカルリンク整合を確認

## 残リスク
- リンク検証は #377 の対象 docs に絞ったローカル相対リンク確認のみ
- Issue 本文の close は PR merge 後に行われる