### PR TITLE
feat(orchestration): reflect worker registry ownership boundary

### DIFF
--- a/docs/worker-registry-coordination.md
+++ b/docs/worker-registry-coordination.md
@@ -72,6 +72,8 @@ registry が担わないもの:
 - registry へ worker 状態を append する writer
 - 書いてよいのは worker の runtime 状態のみ
 - claim の取得 / 解放 / handoff 完了をこの command 単体で成立させない
+- baseline 実装では `--current-issue` を **registry hint** として扱い、
+  ownership を表す入力にはしない
 
 ### dashboard / `ai-board`
 
@@ -80,6 +82,8 @@ registry が担わないもの:
   ownership 判定ロジックは dashboard に持たせない
 - registry と GitHub 側に不一致がある場合は、
   GitHub claim/handoff を優先し、dashboard 側は stale / unknown として扱う
+- baseline 実装では board row に `current_issue_source=registry_hint` と
+  `ownership_source=github_issue` を含め、表示上も ownership 境界を注記する
 
 ## GitHub metadata との責務分担
 
@@ -133,6 +137,39 @@ GitHub 側と registry 側で状態がずれた場合は、次の順で扱う。
 
 このルールにより、二重書きの見かけ上の不整合が起きても
 「どちらを信じるべきか」が固定される。
+
+## baseline implementation mapping
+
+現行 baseline では、責務分担を次の経路に反映する。
+
+- `worker-status-set`: `worker` domain event を append するだけで、
+  claim / release / handoff は成立させない
+- `ai-board` / `worker-board --json`: `current_issue` を返すが、
+  併せて `current_issue_source=registry_hint` と
+  `ownership_source=github_issue` を返す
+- `ai-board` の標準出力: issue 列が hint であり、
+  claim/handoff ownership は GitHub 側にあることを注記する
+
+手動検証の最小手順:
+
+```bash
+python -m personal_mcp.server worker-status-set \
+  --worker-id claude-1 \
+  --terminal-id tty-1 \
+  --current-issue 379 \
+  --status working \
+  --data-dir /tmp/og-registry-check
+
+python -m personal_mcp.server ai-board --json --data-dir /tmp/og-registry-check
+python -m personal_mcp.server ai-board --data-dir /tmp/og-registry-check
+```
+
+期待結果:
+
+- JSON 出力に `current_issue`, `current_issue_source`, `ownership_source` が含まれる
+- `current_issue_source` は `registry_hint`
+- `ownership_source` は `github_issue`
+- テキスト出力に「issue は registry hint」「ownership は GitHub」という注記が出る
 
 ## follow-up items
 

--- a/src/personal_mcp/server.py
+++ b/src/personal_mcp/server.py
@@ -113,19 +113,23 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     p_worker_status = sub.add_parser(
         "worker-status-set",
-        help="append an AI worker status event",
+        help="append an AI worker registry event (observability only)",
     )
     p_worker_status.add_argument("--worker-id", required=True)
     p_worker_status.add_argument("--worker-name", default=None)
     p_worker_status.add_argument("--terminal-id", required=True)
-    p_worker_status.add_argument("--current-issue", default=None)
+    p_worker_status.add_argument(
+        "--current-issue",
+        default=None,
+        help="issue hint for the registry board; does not claim ownership",
+    )
     p_worker_status.add_argument("--status", required=True, choices=sorted(ALLOWED_WORKER_STATUSES))
     p_worker_status.add_argument("--data-dir", default=None)
 
     p_worker_board = sub.add_parser(
         "ai-board",
         aliases=["worker-board"],
-        help="display the latest AI worker board",
+        help="display the latest AI worker registry board (ownership stays on GitHub)",
     )
     p_worker_board.add_argument("--data-dir", default=None)
     p_worker_board.add_argument("--json", action="store_true")

--- a/src/personal_mcp/tools/worker.py
+++ b/src/personal_mcp/tools/worker.py
@@ -8,6 +8,8 @@ from personal_mcp.tools.event import event_add
 
 
 ALLOWED_WORKER_STATUSES = frozenset({"working", "waiting", "reviewing", "idle", "done"})
+CURRENT_ISSUE_SOURCE = "registry_hint"
+OWNERSHIP_SOURCE = "github_issue"
 
 
 def _normalize_required(value: str, *, field_name: str) -> str:
@@ -126,6 +128,8 @@ def worker_board_rows(data_dir: Optional[str] = None) -> List[Dict[str, Any]]:
             "worker_name": worker_name,
             "terminal_id": terminal_id,
             "current_issue": normalized_issue,
+            "current_issue_source": CURRENT_ISSUE_SOURCE,
+            "ownership_source": OWNERSHIP_SOURCE,
             "status": status,
             "last_update": record_ts if isinstance(record_ts, str) else None,
         }
@@ -176,4 +180,10 @@ def format_worker_board(rows: List[Dict[str, Any]]) -> str:
     lines.append("  ".join("-" * widths[key] for key in column_order))
     for row in rendered_rows:
         lines.append("  ".join(row[key].ljust(widths[key]) for key in column_order))
+    lines.extend(
+        [
+            "",
+            "note: issue is a registry hint; claim/handoff ownership lives on GitHub",
+        ]
+    )
     return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,6 +211,8 @@ def test_worker_status_set_and_ai_board_json(tmp_path: Path) -> None:
             "worker_name": "Claude-1",
             "terminal_id": "tty-1",
             "current_issue": "#324",
+            "current_issue_source": "registry_hint",
+            "ownership_source": "github_issue",
             "status": "working",
             "last_update": rows[0]["last_update"],
         }
@@ -254,6 +256,8 @@ def test_worker_board_shows_latest_state_per_worker(tmp_path: Path) -> None:
     assert rows[0]["worker_id"] == "claude-1"
     assert rows[0]["worker_name"] == "claude-1"
     assert rows[0]["current_issue"] == "#325"
+    assert rows[0]["current_issue_source"] == "registry_hint"
+    assert rows[0]["ownership_source"] == "github_issue"
     assert rows[0]["status"] == "reviewing"
 
 
@@ -284,6 +288,8 @@ def test_worker_board_prefers_latest_timestamp_over_append_order(tmp_path: Path)
 
     assert len(rows) == 1
     assert rows[0]["current_issue"] == "#325"
+    assert rows[0]["current_issue_source"] == "registry_hint"
+    assert rows[0]["ownership_source"] == "github_issue"
     assert rows[0]["status"] == "reviewing"
     assert rows[0]["last_update"] == "2026-03-11T10:00:00+09:00"
 
@@ -314,6 +320,8 @@ def test_ai_board_default_output_renders_table(tmp_path: Path) -> None:
     assert "terminal" in result.stdout
     assert "Claude-1" in result.stdout
     assert "#324" in result.stdout
+    assert "registry hint" in result.stdout
+    assert "lives on GitHub" in result.stdout
 
 
 def test_worker_status_set_rejects_invalid_status(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- worker registry の `current_issue` を ownership ではなく hint として CLI help / board 出力に明示
- `ai-board --json` に `current_issue_source` と `ownership_source` を追加して source boundary を返す
- registry coordination docs と CLI E2E テストを更新

## Testing
- `ruff check src/personal_mcp/tools/worker.py src/personal_mcp/server.py tests/test_cli.py`
- `ruff format --check src/personal_mcp/tools/worker.py src/personal_mcp/server.py tests/test_cli.py`
- `pytest tests/test_cli.py`

Closes #379