### PR TITLE
fix(heatmap): apply provisional #257 bucket thresholds

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -548,9 +548,9 @@ function buildDashboardFlowPayload(text, extraUiData) {
 
 function heatColor(n) {
   if (n === 0) return '#eeeeee';
-  if (n <= 2) return '#ffd9b3';
-  if (n <= 5) return '#ffaa55';
-  if (n <= 10) return '#ff7700';
+  if (n <= 4) return '#ffd9b3';
+  if (n <= 9) return '#ffaa55';
+  if (n <= 19) return '#ff7700';
   return '#cc4400';
 }
 

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -351,6 +351,17 @@ def test_http_get_dashboard_200(data_dir: Path) -> None:
     assert "再読み込みに失敗しました。再試行してください。" in html
 
 
+def test_http_get_dashboard_uses_issue_257_provisional_thresholds(data_dir: Path) -> None:
+    handler_cls = _make_handler_for_test(str(data_dir))
+    _, _, html = _do_get_html(handler_cls, "/dashboard")
+    assert "if (n === 0) return '#eeeeee';" in html
+    assert "if (n <= 4) return '#ffd9b3';" in html
+    assert "if (n <= 9) return '#ffaa55';" in html
+    assert "if (n <= 19) return '#ff7700';" in html
+    assert "return '#cc4400';" in html
+    assert "if (n <= 2) return '#ffd9b3';" not in html
+
+
 def test_http_get_root_returns_dashboard_html(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
     _, _, root_html = _do_get_html(handler_cls, "/")


### PR DESCRIPTION
## Summary
- `#257` の provisional decision に合わせて dashboard heatmap の inline threshold を更新
- bucket を `0 / 1..4 / 5..9 / 10..19 / 20+` に変更
- 埋め込み dashboard script がこの threshold を使うことを test で固定

## Scope
- `shipped_density` の current semantics は変更しない
- source-specific scale gap の normalization は扱わない（`#407` の範囲）
- recent 28-day dashboard heatmap の色分岐のみを最小差分で更新

## Validation
- `pytest -q tests/test_heatmap_summary.py`
- `ruff check src/personal_mcp/adapters/http_server.py tests/test_heatmap_summary.py`
- `ruff format --check src/personal_mcp/adapters/http_server.py tests/test_heatmap_summary.py`

## Notes
- 現状データではこの threshold でも濃淡差はまだ弱く、根本要因の source-specific scale gap は `#407` に残る
- `#327` は現 decision と不一致のため close し、この PR で切り直している

Refs #257
