### PR TITLE
feat(heatmap-ui): implement recent 6-week primary view

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -371,7 +371,7 @@ h2 { font-size: 1.1rem; margin: 0; }
   color: #666;
   text-align: right;
 }
-.heatmap { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 0.5rem; }
+.heatmap { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 0.5rem; }
 .heatmap-week { display: grid; grid-template-rows: auto repeat(7, 1fr); gap: 3px; min-width: 0; }
 .heatmap-week-label {
   font-size: 0.72rem;
@@ -478,10 +478,10 @@ h2 { font-size: 1.1rem; margin: 0; }
 <body>
 <section class="heatmap-shell" aria-labelledby="heatmap-title">
   <div class="heatmap-header">
-    <h2 id="heatmap-title">直近5週間</h2>
+    <h2 id="heatmap-title">直近6週間</h2>
     <div id="heatmap-range-label" class="heatmap-subtitle" aria-live="polite"></div>
   </div>
-  <div class="heatmap" id="heatmap" aria-label="直近5週間のヒートマップ"></div>
+  <div class="heatmap" id="heatmap" aria-label="直近6週間のヒートマップ"></div>
 </section>
 <button type="button" id="refresh-btn">再読み込み</button>
 <div class="candidate-mode-switcher" aria-label="候補タグ動作切替">
@@ -1001,9 +1001,9 @@ def _make_handler(data_dir: str):
                 else:
                     self._json(200, rec)
             elif parsed.path == "/api/heatmap":
-                self._json(200, count_events_by_date(35, data_dir or None))
+                self._json(200, count_events_by_date(42, data_dir or None))
             elif parsed.path == "/api/heatmap/debug":
-                self._json(200, count_events_by_date_debug(35, data_dir or None))
+                self._json(200, count_events_by_date_debug(42, data_dir or None))
             elif parsed.path == "/api/candidates":
                 self._json(200, list_candidates(data_dir or None))
             elif parsed.path == "/api/summaries/list":

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -344,7 +344,7 @@ def test_http_get_dashboard_200(data_dir: Path) -> None:
     statuses, headers, html = _do_get_html(handler_cls, "/dashboard")
     assert statuses == [200]
     assert headers["Content-Type"] == "text/html; charset=utf-8"
-    assert "直近5週間" in html
+    assert "直近6週間" in html
     assert 'id="heatmap"' in html
     assert 'id="heatmap-range-label"' in html
     assert 'id="refresh-btn"' in html
@@ -395,7 +395,7 @@ def test_http_get_heatmap_200(data_dir: Path) -> None:
     assert len(resp) == 1
     status, body = resp[0]
     assert status == 200
-    assert len(body) == 35
+    assert len(body) == 42
     assert all("date" in item and "count" in item for item in body)
 
 
@@ -471,11 +471,11 @@ def test_http_get_dashboard_candidate_tap_script_exists(data_dir: Path) -> None:
     assert 'postUiEvent("input_started"' in html
 
 
-def test_http_get_dashboard_renders_recent_5_weeks_heatmap_script(data_dir: Path) -> None:
+def test_http_get_dashboard_renders_recent_6_weeks_heatmap_script(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
     _, _, html = _do_get_html(handler_cls, "/dashboard")
-    assert 'class="heatmap" id="heatmap" aria-label="直近5週間のヒートマップ"' in html
-    assert "grid-template-columns: repeat(5, minmax(0, 1fr));" in html
+    assert 'class="heatmap" id="heatmap" aria-label="直近6週間のヒートマップ"' in html
+    assert "grid-template-columns: repeat(6, minmax(0, 1fr));" in html
     assert "function splitHeatmapIntoWeeks(data) {" in html
     assert "weekColumn.className = 'heatmap-week';" in html
     assert "weekLabel.className = 'heatmap-week-label';" in html
@@ -600,7 +600,7 @@ def test_http_get_heatmap_debug_200(data_dir: Path) -> None:
     assert len(resp) == 1
     status, body = resp[0]
     assert status == 200
-    assert len(body) == 35
+    assert len(body) == 42
     expected_keys = {"date", "raw_count", "shipped_density", "telemetry_count", "life_count"}
     assert all(set(item.keys()) == expected_keys for item in body)
 


### PR DESCRIPTION
Closes #357

## 概要
- dashboard の heatmap を直近6週間の primary view に更新
- `/api/heatmap` と `/api/heatmap/debug` の shipped window を 42 日へ拡張
- 42 日配列を 7 日ごとの 6 列に分けて横方向の時間進行が読める表示へ変更

## 変更内容
- heatmap header と aria label を 6 週間前提に更新
- heatmap を 6 列の week-column レイアウトへ変更
- zero-value day を含む 42 日窓を shipped endpoint で返すように変更
- dashboard / API の前提に合わせてテストを更新

## 実行コマンド
- `ruff check .`
- `ruff format --check .`
- `pytest`
- `pytest tests/test_heatmap_summary.py -k 'http_get_dashboard or http_get_heatmap_200 or http_get_heatmap_returns_shipped_density_for_mixed_day or http_get_heatmap_debug_200 or dashboard_layout_order'`

## 結果
- `ruff check .`: 成功
- `ruff format --check .`: 成功
- focused heatmap pytest: 成功（11 passed）
- `pytest`: 1 failure
  - `tests/test_heatmap_summary.py::test_heatmap_density_audit_uses_last_365_days_as_primary_window`
  - `result["all_time_reference"]["stats"]["total_days"]` が `401` 想定に対して `402`
  - 今回未変更の `heatmap_density_audit()` 系で再現

## 残リスク
- recent 6 weeks は rolling 42 days として実装しており、calendar week strict alignment は別論点のままです
- older history navigation 自体は `#391` の責務として未着手です