### PR TITLE
ci: add CodeQL workflow for branch pushes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    strategy:
+      matrix:
+        language: [ 'python' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## 関連Issue
- なし

## 概要
- 変更内容: GitHub Actions に CodeQL ワークフローを追加しました。
- 理由: `main` 向け PR だけでなく、作業ブランチへの push 時点でも CodeQL を実行するためです。

## 検証
- python: 未実施（workflow 追加のみ）
- ruff: 未実施（workflow 追加のみ）
- pytest: 未実施（workflow 追加のみ）
- `ruff check .`: 未実施（workflow 追加のみ）
- `pytest`: 未実施（workflow 追加のみ）

## レビューノート
- スコープ: `.github/workflows/codeql.yml` の追加のみ
- 挙動変更: `push` では全ブランチ、`pull_request` では `main` 向け PR、`schedule` では毎週月曜に CodeQL が走ります。
- リスク: GitHub Actions 上での初回実行まで workflow 妥当性は未確認です。
- 緩和策: 初回 CI 実行結果を確認します。

## 最小修正
- 適用内容: `push.branches` 制限を付けず、ブランチ push でも CodeQL が動く構成にしました。
- 理由: レビューで指摘した不足点を局所修正で解消するためです。

## 次のIssue
- なし