### PR TITLE
docs: simplify CODEOWNERS to single-owner baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Single-owner baseline. Add narrower paths only when reviewer routing diverges.
+* @wakadorimk2


### PR DESCRIPTION
## 関連Issue
- なし

## 概要
- 変更内容: `.github/CODEOWNERS` を単一 owner の最小構成に整理
- 理由: 現状は全パスが同一 owner で、個別ルールが reviewer routing を変えていなかったため

## 検証
- python: `Python 3.10.12`
- ruff: `ruff check .`
- pytest: `pytest`
- `ruff check .`: success
- `pytest`: 376 passed, 12 skipped

## レビューノート
- スコープ: `.github/CODEOWNERS` の新規追加のみ
- 挙動変更: path ごとの冗長な owner 指定をなくし、単一 owner baseline を明示
- リスク: 将来 path ごとに reviewer を分ける場合は再度ルール追加が必要
- 緩和策: コメントで narrower paths を追加する条件を明記

## 最小修正
- 適用内容: `* @wakadorimk2` の 1 ルールに集約
- 理由: 実際の GitHub 挙動とファイル内容を一致させるため

## 次のIssue
- なし
