### PR TITLE
feat(web): add /app static serving and packaging smoke coverage

### DIFF
--- a/src/personal_mcp/adapters/http_server.py
+++ b/src/personal_mcp/adapters/http_server.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import mimetypes
+import os.path
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -362,6 +364,23 @@ _DASHBOARD_HTML = load_dashboard_html().replace(
 )
 
 
+_APP_ROOT = files("personal_mcp.web").joinpath("app")
+
+
+def _sanitize_subpath(raw: str) -> str:
+    """Return a safe relative path within app root, stripping traversal attempts."""
+    parts: list[str] = []
+    for part in raw.lstrip("/").split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+        else:
+            parts.append(part)
+    return "/".join(parts)
+
+
 def _make_html() -> str:
     domain_opts = "\n      ".join(
         f'<option value="{d}">{d}</option>' for d in sorted(ALLOWED_DOMAINS)
@@ -389,6 +408,36 @@ def _make_handler(data_dir: str):
                 self.wfile.write(payload)
             except (BrokenPipeError, ConnectionResetError):
                 return
+
+        def _serve_app(self, subpath: str) -> None:
+            index = _APP_ROOT.joinpath("index.html")
+            if not index.is_file():
+                self._json(
+                    503,
+                    {"error": "frontend not built", "hint": "run pnpm build in frontend/ first"},
+                )
+                return
+            target = _APP_ROOT
+            for part in subpath.split("/"):
+                if part:
+                    target = target.joinpath(part)
+            if target.is_file():
+                fname = subpath.split("/")[-1] if subpath else "index.html"
+            else:
+                # Distinguish SPA routes (no ext / .html) from missing assets
+                leaf = subpath.split("/")[-1] if subpath else ""
+                _, ext = os.path.splitext(leaf)
+                if ext and ext.lower() not in (".html", ".htm"):
+                    # e.g. /app/assets/missing.js → 404, not SPA fallback
+                    self._json(404, {"error": "not found"})
+                    return
+                # SPA fallback: extension-less or .html path → serve index.html
+                target = index
+                fname = "index.html"
+            data = target.read_bytes()
+            ct, _ = mimetypes.guess_type(fname)
+            charset = "utf-8" if ct == "text/html" else None
+            self._write_response(200, ct or "application/octet-stream", data, charset=charset)
 
         def _json(self, status: int, body: Any) -> None:
             payload = json.dumps(body, ensure_ascii=False).encode()
@@ -433,6 +482,9 @@ def _make_handler(data_dir: str):
                 self._json(200, list_candidates(data_dir or None))
             elif parsed.path == "/api/summaries/list":
                 self._json(200, list_summaries(28, data_dir or None))
+            elif parsed.path == "/app" or parsed.path.startswith("/app/"):
+                subpath = _sanitize_subpath(parsed.path[len("/app") :])
+                self._serve_app(subpath)
             else:
                 self._json(404, {"error": "not found"})
 

--- a/tests/test_http_server_app.py
+++ b/tests/test_http_server_app.py
@@ -1,0 +1,174 @@
+# tests/test_http_server_app.py
+#
+# /app/ static serving と SPA fallback の unit / integration テスト (#445)
+# build artifact は fake_app_root fixture で hermetic に生成し、
+# CI の pnpm build や git 管理外 artifact に依存しない。
+from __future__ import annotations
+
+import http.client
+import json
+import threading
+from unittest.mock import patch
+
+import pytest
+from http.server import HTTPServer
+
+from personal_mcp.adapters import http_server
+from personal_mcp.adapters.http_server import _make_handler, _sanitize_subpath
+
+
+# ─── _sanitize_subpath ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", ""),
+        ("/", ""),
+        ("/index.html", "index.html"),
+        ("assets/foo.js", "assets/foo.js"),
+        ("/assets/foo.js", "assets/foo.js"),
+        ("../etc/passwd", "etc/passwd"),
+        ("/../etc/passwd", "etc/passwd"),
+        ("a/../../b", "b"),
+        ("a/../b", "b"),
+        ("a/./b", "a/b"),
+    ],
+)
+def test_sanitize_subpath(raw: str, expected: str) -> None:
+    assert _sanitize_subpath(raw) == expected
+
+
+# ─── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def fake_app_root(tmp_path_factory):
+    """Minimal Vite build artifact tree for hermetic testing (pnpm build 不要)."""
+    app_dir = tmp_path_factory.mktemp("app")
+    (app_dir / "index.html").write_bytes(b"<!DOCTYPE html><html><body>app</body></html>")
+    (app_dir / "assets").mkdir()
+    (app_dir / "assets" / "main.js").write_bytes(b"console.log('main')")
+    (app_dir / "assets" / "style.css").write_bytes(b"body { margin: 0; }")
+    return app_dir
+
+
+@pytest.fixture(scope="module", autouse=True)
+def patch_app_root(fake_app_root):
+    """_APP_ROOT をモジュール全体で fake_app_root に向ける。"""
+    with patch.object(http_server, "_APP_ROOT", fake_app_root):
+        yield fake_app_root
+
+
+@pytest.fixture(scope="module")
+def server_port(tmp_path_factory, patch_app_root):
+    data_dir = str(tmp_path_factory.mktemp("data"))
+    handler = _make_handler(data_dir)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever)
+    t.daemon = True
+    t.start()
+    yield port
+    server.shutdown()
+
+
+def _get(port: int, path: str) -> http.client.HTTPResponse:
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request("GET", path)
+    return conn.getresponse()
+
+
+# ─── /app/ serving (build exists) ─────────────────────────────────────────────
+
+
+def test_app_root_serves_index_html(server_port: int) -> None:
+    resp = _get(server_port, "/app/")
+    assert resp.status == 200
+    ct = resp.getheader("Content-Type", "")
+    assert "text/html" in ct
+    assert b"<!DOCTYPE html>" in resp.read()
+
+
+def test_app_index_html_explicit(server_port: int) -> None:
+    resp = _get(server_port, "/app/index.html")
+    assert resp.status == 200
+    assert b"<!DOCTYPE html>" in resp.read()
+
+
+def test_app_no_trailing_slash(server_port: int) -> None:
+    resp = _get(server_port, "/app")
+    assert resp.status == 200
+    assert b"<!DOCTYPE html>" in resp.read()
+
+
+def test_app_assets_js(server_port: int) -> None:
+    resp = _get(server_port, "/app/assets/main.js")
+    assert resp.status == 200
+    assert "javascript" in resp.getheader("Content-Type", "")
+
+
+def test_app_assets_css(server_port: int) -> None:
+    resp = _get(server_port, "/app/assets/style.css")
+    assert resp.status == 200
+    assert "css" in resp.getheader("Content-Type", "")
+
+
+# ─── SPA fallback ─────────────────────────────────────────────────────────────
+
+
+def test_app_spa_fallback_for_unknown_route(server_port: int) -> None:
+    """拡張子なし未知パス → SPA fallback (200 index.html)。"""
+    resp = _get(server_port, "/app/some-unknown-react-route")
+    assert resp.status == 200
+    assert "text/html" in resp.getheader("Content-Type", "")
+
+
+def test_app_spa_fallback_for_html_extension(server_port: int) -> None:
+    """.html 拡張子で存在しないパス → SPA fallback。"""
+    resp = _get(server_port, "/app/nonexistent-page.html")
+    assert resp.status == 200
+    assert b"<!DOCTYPE html>" in resp.read()
+
+
+def test_app_missing_asset_returns_404(server_port: int) -> None:
+    """.js / .css などの asset パスが存在しない → 404 (SPA fallback しない)。"""
+    for path in ("/app/assets/nonexistent.js", "/app/assets/nonexistent.css"):
+        resp = _get(server_port, path)
+        resp.read()  # drain
+        assert resp.status == 404, f"expected 404 for {path}"
+
+
+# ─── 503 when build missing ───────────────────────────────────────────────────
+
+
+def test_app_503_when_no_build(tmp_path) -> None:
+    handler = _make_handler(str(tmp_path))
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever)
+    t.daemon = True
+    t.start()
+    try:
+        # 空ディレクトリを指すことで index.html が存在しない状態を再現
+        with patch.object(http_server, "_APP_ROOT", tmp_path):
+            resp = _get(port, "/app/")
+            assert resp.status == 503
+            body = json.loads(resp.read())
+            assert "hint" in body
+            assert "pnpm build" in body["hint"]
+    finally:
+        server.shutdown()
+
+
+# ─── 既存ルートの非回帰 ───────────────────────────────────────────────────────
+
+
+def test_health_route_unchanged(server_port: int) -> None:
+    resp = _get(server_port, "/health")
+    assert resp.status == 200
+
+
+def test_unknown_route_still_404(server_port: int) -> None:
+    resp = _get(server_port, "/not-a-real-path-xyz")
+    assert resp.status == 404

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import zipfile
@@ -52,3 +53,60 @@ def test_wheel_contains_dashboard_template_and_can_load_it(tmp_path: Path) -> No
     )
 
     assert result.returncode == 0
+
+
+def test_app_root_traversable_resolves_from_installed_package(tmp_path: Path) -> None:
+    """Documented web/app resource contract remains readable after wheel install."""
+    repo_root = Path(__file__).resolve().parent.parent
+    repo_copy = tmp_path / "repo"
+    dist_dir = tmp_path / "dist"
+
+    shutil.copytree(repo_root, repo_copy)
+
+    app_dir = repo_copy / "src" / "personal_mcp" / "web" / "app"
+    app_dir.mkdir(parents=True, exist_ok=True)
+    expected_html = "<!DOCTYPE html><html><body>packaged app</body></html>"
+    (app_dir / "index.html").write_text(expected_html, encoding="utf-8")
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--no-isolation",
+            "--outdir",
+            str(dist_dir),
+        ],
+        cwd=repo_copy,
+        check=True,
+    )
+
+    wheel_path = next(dist_dir.glob("*.whl"))
+    with zipfile.ZipFile(wheel_path) as zf:
+        zf.extractall(tmp_path / "site")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path / "site")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from importlib.resources import files; "
+                "index = files('personal_mcp').joinpath('web/app/index.html'); "
+                "assert index.is_file(); "
+                "text = index.read_text(encoding='utf-8'); "
+                "assert 'packaged app' in text; "
+                "print('ok')"
+            ),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "ok" in result.stdout


### PR DESCRIPTION
## 関連Issue
- Closes #445

## 概要
- 変更内容: Python HTTP サーバに /app/ static serving、SPA fallback、missing-build 503、missing asset 404 を追加
- 理由: 新 UI 配信契約を実装しつつ、frontend build 非依存の hermetic test と installed wheel 上の packaging smoke を整えるため

## 検証
- python: 3.10
- ruff: pass
- pytest: pass
- `ruff check .`: pass
- `pytest`: pass (411 passed)

## レビューノート
- スコープ: Issue #445 の Python HTTP server /app/ serving と検証追加に限定
- 挙動変更: /app/ 配信追加、未知 SPA route は index.html fallback、missing asset は 404、build 未配置は 503
- リスク: wheel packaging smoke が build artifact 契約に触れるため packaging path の変更に影響を受ける
- 緩和策: hermetic test で fake app root を使い、packaging smoke では temp copy に synthetic web/app/index.html を作って契約を固定

## 最小修正
- 適用内容: documented importlib.resources contract を assert する smoke test と /app/ 回りの最小実装・回帰テストを追加
- 理由: issue 完了条件を満たしつつ、git 管理外 artifact や CI frontend build に依存しない検証へ寄せるため

## 次のIssue
- なし
