### PR TITLE
ci(frontend): frontend build を最小 CI に組み込む

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,26 @@ jobs:
 
       - name: pytest
         run: pytest
+
+  frontend-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: frontend/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        working-directory: frontend
+        run: pnpm build


### PR DESCRIPTION
## 概要
- CI に frontend build 専用 job を追加
- GitHub Actions 上で Node / pnpm をセットアップ
- `frontend/` で `pnpm install --frozen-lockfile` と `pnpm build` を実行

## 確認
- `git diff --check`
- 静的レビューで issue #446 のスコープとの一致を確認

Closes #446