### PR TITLE
fix(packaging): web/app 未 build 時に wheel build を失敗させる

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -54,7 +54,7 @@ boundary.
 **`web/app/` は generated artifact** — 以下の制約に注意:
 
 - `pip wheel` / `python -m build` 前に必ず `pnpm build` を実行すること
-- ビルド未実施のまま `pip wheel` / `python -m build` / non-editable な `pip install .` を実行すると、packaging は `run pnpm build in frontend/ first` を含む明示的エラーで停止する
+- ビルド未実施、または `index.html` だけ残って `assets/` bundle が欠けた状態で `pip wheel` / `python -m build` / non-editable な `pip install .` を実行すると、packaging は `run pnpm build in frontend/ first` を含む明示的エラーで停止する
 - `make frontend-check` でビルド成果物の存在を事前確認できる
 
 Python 側で `/app/` を配信する際は `importlib.resources.files("personal_mcp").joinpath("web/app")` を起点として読む。

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,15 @@ from setuptools.command.sdist import sdist
 FRONTEND_INDEX = (
     Path(__file__).resolve().parent / "src" / "personal_mcp" / "web" / "app" / "index.html"
 )
+FRONTEND_ASSETS_DIR = FRONTEND_INDEX.parent / "assets"
 
 
 def ensure_frontend_artifact() -> None:
     if not FRONTEND_INDEX.is_file():
+        raise RuntimeError("frontend build missing: run pnpm build in frontend/ first")
+    if not FRONTEND_ASSETS_DIR.is_dir() or not any(
+        path.is_file() for path in FRONTEND_ASSETS_DIR.rglob("*")
+    ):
         raise RuntimeError("frontend build missing: run pnpm build in frontend/ first")
 
 

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -24,6 +24,10 @@ def _write_frontend_index(
     app_dir = repo_root / "src" / "personal_mcp" / "web" / "app"
     app_dir.mkdir(parents=True, exist_ok=True)
     (app_dir / "index.html").write_text(html, encoding="utf-8")
+    assets_dir = app_dir / "assets"
+    assets_dir.mkdir(exist_ok=True)
+    (assets_dir / "main.js").write_text("console.log('main')", encoding="utf-8")
+    (assets_dir / "style.css").write_text("body { margin: 0; }", encoding="utf-8")
 
 
 def _build_wheel(
@@ -157,6 +161,20 @@ def test_build_fails_with_hint_when_frontend_artifact_is_missing(tmp_path: Path)
     dist_dir = tmp_path / "dist"
 
     shutil.rmtree(repo_copy / "src" / "personal_mcp" / "web" / "app", ignore_errors=True)
+    shutil.rmtree(repo_copy / "build", ignore_errors=True)
+
+    result = _build_wheel(repo_copy, dist_dir, check=False)
+
+    assert result.returncode != 0
+    assert "run pnpm build in frontend/ first" in (result.stderr + result.stdout)
+
+
+def test_build_fails_with_hint_when_frontend_assets_are_missing(tmp_path: Path) -> None:
+    repo_copy = _copy_repo(tmp_path)
+    dist_dir = tmp_path / "dist"
+
+    _write_frontend_index(repo_copy)
+    shutil.rmtree(repo_copy / "src" / "personal_mcp" / "web" / "app" / "assets")
     shutil.rmtree(repo_copy / "build", ignore_errors=True)
 
     result = _build_wheel(repo_copy, dist_dir, check=False)


### PR DESCRIPTION
## 概要
- packaging 時に frontend artifact の存在チェックを追加
- web/app 未 build の場合は `run pnpm build in frontend/ first` を含む明示的エラーで停止
- packaging smoke test を repo copy ベースに整理し、未 build 失敗ケースを追加

## テスト
- `RUFF_CACHE_DIR=/tmp/ruff-cache-og-builder python -m ruff check setup.py tests/test_packaging_smoke.py`
- `python -m pytest -o cache_dir=/tmp/pytest-cache-og-builder tests/test_packaging_smoke.py`

Closes #454