### PR TITLE
fix(web): align issue #356 heatmap palette tests

### DIFF
--- a/src/personal_mcp/web/templates/dashboard.html
+++ b/src/personal_mcp/web/templates/dashboard.html
@@ -67,6 +67,21 @@
             box-shadow: inset 0 0 0 1px #e6e6e6;
         }
 
+        /* heatmap palette: reassurance-oriented visual tokens (#356) */
+        :root {
+            --heatmap-bucket-0: #efefef;
+            --heatmap-bucket-1: #d5e8d0;
+            --heatmap-bucket-2: #9ec899;
+            --heatmap-bucket-3: #5fa058;
+            --heatmap-bucket-4: #3a7035;
+        }
+
+        .heatmap-cell--bucket-0 { background: var(--heatmap-bucket-0); }
+        .heatmap-cell--bucket-1 { background: var(--heatmap-bucket-1); }
+        .heatmap-cell--bucket-2 { background: var(--heatmap-bucket-2); }
+        .heatmap-cell--bucket-3 { background: var(--heatmap-bucket-3); }
+        .heatmap-cell--bucket-4 { background: var(--heatmap-bucket-4); }
+
         #candidates {
             margin-bottom: 1rem;
             display: flex;
@@ -318,13 +333,6 @@
             return payload;
         }
 
-        function heatColor(n) {
-            var colors = ['#eeeeee', '#ffd9b3', '#ffaa55', '#ff7700', '#cc4400'];
-            if (n < 0) return colors[0];
-            if (n >= colors.length) return colors[colors.length - 1];
-            return colors[n];
-        }
-
         function monthDayLabel(dateText) {
             var parts = (dateText || "").split("-");
             if (parts.length !== 3) return dateText || "";
@@ -484,8 +492,9 @@
 
                 week.forEach(function (item) {
                     var cell = document.createElement('div');
-                    cell.className = item.count === 0 ? 'heatmap-cell heatmap-cell-empty' : 'heatmap-cell';
-                    cell.style.background = heatColor(item.bucket_index);
+                    var bucketIdx = Math.max(0, Math.min(4, item.bucket_index || 0));
+                    cell.className = 'heatmap-cell heatmap-cell--bucket-' + bucketIdx;
+                    if (item.count === 0) cell.classList.add('heatmap-cell-empty');
                     cell.title = item.date + ': ' + item.count + '件';
                     cell.setAttribute('aria-label', item.date + ': ' + item.count + '件');
                     weekColumn.appendChild(cell);

--- a/tests/test_heatmap_summary.py
+++ b/tests/test_heatmap_summary.py
@@ -355,10 +355,14 @@ def test_http_get_dashboard_200(data_dir: Path) -> None:
 def test_http_get_dashboard_uses_issue_257_bucket_contract(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
     _, _, html = _do_get_html(handler_cls, "/dashboard")
-    assert "var colors = ['#eeeeee', '#ffd9b3', '#ffaa55', '#ff7700', '#cc4400'];" in html
-    assert "cell.style.background = heatColor(item.bucket_index);" in html
-    assert "if (n < 0) return colors[0];" in html
-    assert "if (n >= colors.length) return colors[colors.length - 1];" in html
+    assert "--heatmap-bucket-0: #efefef;" in html
+    assert "--heatmap-bucket-1: #d5e8d0;" in html
+    assert "--heatmap-bucket-2: #9ec899;" in html
+    assert "--heatmap-bucket-3: #5fa058;" in html
+    assert "--heatmap-bucket-4: #3a7035;" in html
+    assert ".heatmap-cell--bucket-0 { background: var(--heatmap-bucket-0); }" in html
+    assert ".heatmap-cell--bucket-4 { background: var(--heatmap-bucket-4); }" in html
+    assert "var bucketIdx = Math.max(0, Math.min(4, item.bucket_index || 0));" in html
     assert "if (n <= 2) return '#ffd9b3';" not in html
 
 
@@ -513,8 +517,10 @@ def test_http_get_dashboard_renders_recent_6_weeks_heatmap_script(data_dir: Path
 def test_http_get_dashboard_uses_heatmap_bucket_index_for_color(data_dir: Path) -> None:
     handler_cls = _make_handler_for_test(str(data_dir))
     _, _, html = _do_get_html(handler_cls, "/dashboard")
-    assert "var colors = ['#eeeeee', '#ffd9b3', '#ffaa55', '#ff7700', '#cc4400'];" in html
-    assert "cell.style.background = heatColor(item.bucket_index);" in html
+    assert "cell.className = 'heatmap-cell heatmap-cell--bucket-' + bucketIdx;" in html
+    assert "if (item.count === 0) cell.classList.add('heatmap-cell-empty');" in html
+    assert "cell.style.background = heatColor(item.bucket_index);" not in html
+    assert "function heatColor(n) {" not in html
     assert "cell.title = item.date + ': ' + item.count + '件';" in html
 
 


### PR DESCRIPTION
Refs #356

## 概要
- heatmap の reassurance-oriented palette を CSS token + bucket class ベースで適用
- `heatColor()` と inline `style.background` 前提を削除
- dashboard template の文字列検証を palette/class 前提へ更新し、旧実装の不在も回帰検知に追加

## 変更内容
- `dashboard.html` に `--heatmap-bucket-0..4` と `.heatmap-cell--bucket-0..4` を追加
- heatmap セル描画を `bucketIdx` clamp + class 付与へ変更
- `tests/test_heatmap_summary.py` を旧 color array/`heatColor()` 前提から新 palette/class 前提へ更新

## 実行コマンド
```bash
pytest /home/wakadori/projects/orange-garden/tests/test_heatmap_summary.py -q
ruff check tests/test_heatmap_summary.py
ruff format --check tests/test_heatmap_summary.py
```

## 結果
- `pytest`: 47 passed
- `ruff check`: All checks passed
- `ruff format --check`: 1 file already formatted

## 残リスク
- heatmap の見た目確認はブラウザ手動確認を未実施
