### PR TITLE
docs: sync heatmap six-week primary view policy

### DIFF
--- a/docs/heatmap-state-density-spec.md
+++ b/docs/heatmap-state-density-spec.md
@@ -86,6 +86,12 @@ shipped_density[date] = count(events WHERE
 
 **現在の実装**: `#317` 適用後の `/api/heatmap` は `shipped_density` を返している。
 
+### Current baseline vs future UI range
+
+- current baseline: `/api/heatmap` は直近 28 日の `shipped_density` を返す
+- future `/app/` shipped UI policy: primary heatmap view は recent 6 weeks を前提に構成する（#353, #357, #408）
+- したがって、28-day API baseline と 6-week UI primary view は同一の決定ではなく、後者は range aggregation / UI issue 側で扱う
+
 ### 3.1 Population seam (Issue #332)
 
 Issue #332 は heatmap semantics の再定義ではなく、legacy telemetry を scale 母集団から分離するための

--- a/docs/heatmap-temporal-aggregation-spec.md
+++ b/docs/heatmap-temporal-aggregation-spec.md
@@ -21,6 +21,7 @@ The output is a contract that:
 
 This document defines a future-state contract.
 It does not retroactively change the current shipped `/api/heatmap` baseline, which still returns the last local 28 days, and it does not implement anything.
+The intended consumer-side primary view for that future state is the `/app/` main dashboard page tracked by #353, #406, and #357, where the near range is treated as the most recent 6 weeks.
 
 ---
 
@@ -289,6 +290,6 @@ The following are explicitly deferred to other issues:
 - Issue #408 — scope and acceptance criteria for this document
 - Issue #407 — daily metric derivation seam (upstream)
 - Issue #391 — history navigation UI (downstream consumer)
-- Issue #353 — top-level heatmap epic; recent-6-week primary view policy
+- Issue #353 — top-level heatmap epic; recent-6-weeks primary view policy
 - Issue #355 — shared bucket mapping contract (downstream)
-- Issue #357 — recent-6-week primary view implementation (CLOSED)
+- Issue #357 — recent-6-weeks primary view implementation


### PR DESCRIPTION
## Summary
- sync docs with the decision to keep the shipped heatmap primary view at recent 6 weeks
- clarify the distinction between the current 28-day `/api/heatmap` baseline and the future `/app/` UI range
- align references to issues #353, #357, #391, and #408

## Testing
- not run (docs-only change)

Refs #353
Refs #357
Refs #391
Refs #408