### PR TITLE
docs: sync heatmap API 42-day baseline references

### DIFF
--- a/docs/heatmap-metric-derivation-spec.md
+++ b/docs/heatmap-metric-derivation-spec.md
@@ -32,7 +32,7 @@ shipped_density[date] = count(events WHERE
 
 This is the current `display_population`.
 
-Operationally, `/api/heatmap` returns the last local 28 days, including zero-value days, as:
+Operationally, `/api/heatmap` returns the last local 42 days, including zero-value days, as:
 
 ```json
 [{ "date": "YYYY-MM-DD", "count": N }]

--- a/docs/heatmap-state-density-spec.md
+++ b/docs/heatmap-state-density-spec.md
@@ -79,18 +79,18 @@ shipped_density[date] = count(events WHERE
 ```
 
 - 集計単位: ローカル日（timezone-aware）
-- 集計期間: 直近 28 日（当日含む）
+- 集計期間: 直近 42 日（当日含む）
 - データ形状: `[{date: "YYYY-MM-DD", count: N}]`（現在の `/api/heatmap` と同形）
 
 この定義が `/api/heatmap` で返すべき v1 の意味定義。
 
 **現在の実装**: `#317` 適用後の `/api/heatmap` は `shipped_density` を返している。
 
-### Current baseline vs future UI range
+### Current shipped range boundary
 
-- current baseline: `/api/heatmap` は直近 28 日の `shipped_density` を返す
-- future `/app/` shipped UI policy: primary heatmap view は recent 6 weeks を前提に構成する（#353, #357, #408）
-- したがって、28-day API baseline と 6-week UI primary view は同一の決定ではなく、後者は range aggregation / UI issue 側で扱う
+- current shipped baseline: `/api/heatmap` は直近 42 日の `shipped_density` を返す
+- current shipped consumer: maintained dashboard UI（`/` と `/dashboard`）はこの 42-day heatmap を表示する
+- #408 / #391 が扱うのは、この near range を超える history をどう集約・表示するかであり、現行 consumer route の切り替えではない
 
 ### 3.1 Population seam (Issue #332)
 

--- a/docs/heatmap-temporal-aggregation-spec.md
+++ b/docs/heatmap-temporal-aggregation-spec.md
@@ -19,9 +19,8 @@ The output is a contract that:
 - downstream metric work can extend without reopening source-family normalization
 - temporal zoom support can be built on through an explicit future-state range contract
 
-This document defines a future-state contract.
-It does not retroactively change the current shipped `/api/heatmap` baseline, which still returns the last local 28 days, and it does not implement anything.
-The intended consumer-side primary view for that future state is the `/app/` main dashboard page tracked by #353, #406, and #357, where the near range is treated as the most recent 6 weeks.
+This document defines a future-state contract for history ranges beyond the currently shipped near view.
+It does not change the current shipped `/api/heatmap` baseline, which already returns the last local 42 days, and it does not decide which route consumes future range-aware data.
 
 ---
 
@@ -71,7 +70,7 @@ They may be adjusted by implementation without revisiting this document, as long
 
 ### 3.2 Boundary rationale
 
-The current shipped baseline remains the 28-day `/api/heatmap` contract defined in `docs/heatmap-metric-derivation-spec.md`.
+The current shipped baseline remains the 42-day `/api/heatmap` contract defined in `docs/heatmap-metric-derivation-spec.md`.
 
 Within the future-state contract defined here, the near boundary is the most recent 42 days (6 weeks) at daily resolution.
 That future-state boundary should not be changed by #408 or #391 without reopening this policy.


### PR DESCRIPTION
## Summary
- /api/heatmap の shipped baseline 記述を 42 日に同期
- heatmap 関連 docs 間の 28-day / 42-day 不整合を解消
- future history range の説明から現行 route 決め打ちを外し、現状 consumer と将来 range policy を分離

## Verification
- src/personal_mcp/adapters/http_server.py で /api/heatmap が count_events_by_date(42, ...) を返すことを確認
- tests/test_heatmap_summary.py で /api/heatmap と /api/heatmap/debug が 42 件前提であることを確認