### PR TITLE
Add Claude Code Discord notification hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown); wt=$(basename \"$(git rev-parse --show-toplevel 2>/dev/null)\" 2>/dev/null || echo unknown); NOTIFY_CHANNEL=discord /home/wakadori/projects/og-notify/scripts/notify --kind ai_task_completed --source claude_code \"Claude turn completed [$wt/$branch]\"'"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown); wt=$(basename \"$(git rev-parse --show-toplevel 2>/dev/null)\" 2>/dev/null || echo unknown); NOTIFY_CHANNEL=discord /home/wakadori/projects/og-notify/scripts/notify --event needs_input --source claude_code --title \"Claude Code\" \"Claude needs your attention [$wt/$branch]\"'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add project-scoped `.claude/settings.json` hooks for Claude Code
- send both `Stop` and `Notification` hook events through `scripts/notify`
- pin `Notification` to `NOTIFY_CHANNEL=discord` so it does not depend on inherited env

## Validation
- `jq . .claude/settings.json`
- Stop dry-run resolves `channel=discord` and `event=task_completed`
- Notification dry-run resolves `channel=discord` and `event=needs_input`
- Notification dry-run from `/tmp` still succeeds with fallback metadata (`[/unknown]`)
